### PR TITLE
Partially revert #2

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,7 +47,7 @@ Code generation system
     :members:
     :special-members:
 
-.. autoclass:: C89CodePrinter
+.. autoclass:: CPrinter
     :members:
     :special-members:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -10,6 +10,6 @@ definitions can be given to the :py:func:`optimize` function, then a
 mathematically-equivalent list of tensor definitions will be returned, possibly
 incurring much less arithmetic cost.   For any iterable of tensor definitions,
 whether from the gristmill optimizer or not, the code printers
-:py:class:`FortranPrinter`, :py:class:`C89CodePrinter`, and
+:py:class:`FortranPrinter`, :py:class:`CPrinter`, and
 :py:class:`EinsumPrinter` can be used to generate code automatically.  The exact
 form of the generated code is very tunable.

--- a/gristmill/__init__.py
+++ b/gristmill/__init__.py
@@ -4,7 +4,7 @@ Public names are going to be imported here.
 """
 
 from .generate import (
-    BasePrinter, NaiveCodePrinter, C89CodePrinter, FortranPrinter,
+    BasePrinter, NaiveCodePrinter, CPrinter, FortranPrinter,
     EinsumPrinter, mangle_base
 )
 from .optimize import optimize, verify_eval_seq, ContrStrat, RepeatedTermsStrat
@@ -21,7 +21,7 @@ __all__ = [
     'BasePrinter',
     'mangle_base',
     'NaiveCodePrinter',
-    'C89CodePrinter',
+    'CPrinter',
     'FortranPrinter',
     'EinsumPrinter'
 ]


### PR DESCRIPTION
I confused the C printer of SymPy with that of Gristmill. I should have modified the name of former only.