### PR TITLE
Add missing include

### DIFF
--- a/gristmill/_parenth.cpp
+++ b/gristmill/_parenth.cpp
@@ -7,6 +7,7 @@
 #include <Python.h>
 
 #include <cassert>
+#include <cstddef>
 #include <limits>
 #include <vector>
 

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2408,7 +2408,7 @@ class _Optimizer:
         for k, v in pull_info.items():
             pivot = k[0][0]
             assert len(pivot) > 0
-            assert k[0][1] == 1
+            assert abs(k[0][1] - 1) < 1e-12
             if len(v) == 1:
                 # No need to form a new intermediate.
                 base, coeff = v[0]

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -992,7 +992,7 @@ class _BronKerbosch:
                     i for i in to_loop if subg[i].saving == greedy_saving
                 }
                 if cut_full:
-                    to_loop = {random.sample(to_loop, 1).pop()}
+                    to_loop = {random.sample(list(to_loop), 1).pop()}
                     pivots = []
 
         # Designated vertices that can be excluded for each pivot.


### PR DESCRIPTION
Installation using `pip` fails as

```
      In file included from gristmill/_parenth.cpp:13:
      /tmp/pip-install-iwdh__o7/gristmill_8be63384772f4f05b78c42c9c06934b7/deps/cpypp/include/cpypp.hpp:726:29: error: ‘ptrdiff_t’ does not name a type
        726 |     using difference_type = ptrdiff_t;
            |                             ^~~~~~~~~
      /tmp/pip-install-iwdh__o7/gristmill_8be63384772f4f05b78c42c9c06934b7/deps/cpypp/include/cpypp.hpp:17:1: note: ‘ptrdiff_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
         16 | #include <cassert>
        +++ |+#include <cstddef>
         17 | #include <utility>
```