### PR TITLE
fix(build): Use the current scikit-build-core configuration keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10"]
+requires = ["scikit-build-core>=0.10,<2"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["scikit-build-core>=0.10"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-cmake.minimum-version = "3.15"  # Minimum version of CMake
-cmake.verbose = true  # Verbose build for debugging
+cmake.version = ">=3.15"  # Minimum version of CMake
+build.verbose = true  # Verbose build for debugging
 # Don't create a separate subdirectory - install alongside Python source files
 wheel.packages = ["gristmill"]
 sdist.include = ["gristmill/templates/*", "deps/cpypp/include/**/*.hpp", "deps/fbitset/include/**/*.hpp", "deps/libparenth/include/**/*.hpp"]


### PR DESCRIPTION
## Problem

A fresh clone no longer builds. `uv sync --locked --extra dev` fails with:

```
ERROR: Use cmake.version instead of cmake.minimum-version with scikit-build-core >= 0.8
```

and, once that key is fixed:

```
ERROR: Use build.verbose instead of cmake.verbose for scikit-build-core >= 0.10
```

`[tool.scikit-build]` still uses the two pre-0.8/0.10 spellings. They were deprecation warnings when written; scikit-build-core 1.0 turned them into hard errors. Because `[build-system] requires` only says `scikit-build-core>=0.10`, the backend is resolved fresh at build time and is not covered by `uv.lock`, so the breakage arrives without any change to this repository.

This is the same defect as DrudgeCAS/drudge#67, which has the same two keys.

## Changes

- `cmake.minimum-version = "3.15"` becomes `cmake.version = ">=3.15"`. The replacement key takes a version *specifier*, not a bare version.
- `cmake.verbose = true` becomes `build.verbose = true`.

Both are pure renames; the build behaves as before.

## Verification

On macOS with scikit-build-core 1.0.3 and CMake 4.3:

| step | before | after |
| --- | --- | --- |
| `uv sync --locked --extra dev` | fails, `build_editable` exit status 7 | succeeds |
| `DUMMY_SPARK=1 uv run pytest tests` | cannot run | 30 passed, 2 xfailed, 4 failed |

The 4 failures are pre-existing and specific to my machine, not to this change: two Fortran printer tests fail because the local `gfortran` cannot link `_malloc`/`_memset`, and two OMEinsum tests fail because `juliacall` rejects the installed Julia. The 30 passing and 2 xfailed match the counts documented in `.github/copilot-instructions.md`.

## Related

`uv.lock` currently pins `drudge` at `d6e34ab`, which predates drudge's migration to scikit-build-core and therefore still builds. Once that lock is refreshed against current drudge `master`, gristmill will also need DrudgeCAS/drudge#67. No change is needed here for that.

I also verified gristmill against a drudge built on the updated libcanon (DrudgeCAS/libcanon#7, #8, #9, via DrudgeCAS/drudge#68): the test results are identical, same 30 passed / 2 xfailed and the same 4 environment-specific failures. Gristmill does not depend on libcanon directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
