### PR TITLE
deps: Refresh the pinned drudge revision

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -205,8 +205,8 @@ wheels = [
 
 [[package]]
 name = "drudge"
-version = "0.11.2"
-source = { git = "https://github.com/DrudgeCAS/drudge.git?rev=master#de93861f007b4381f083057602b78596a54fede1" }
+version = "0.11.3"
+source = { git = "https://github.com/DrudgeCAS/drudge.git?rev=master#93098b4178a16b0aea9df0deacd16932e96ab31e" }
 dependencies = [
     { name = "dummyrdd" },
     { name = "ipykernel" },

--- a/uv.lock
+++ b/uv.lock
@@ -205,10 +205,11 @@ wheels = [
 
 [[package]]
 name = "drudge"
-version = "0.11.0"
-source = { git = "https://github.com/DrudgeCAS/drudge.git?rev=master#d6e34abb8bb6ef558fd9fd5dbc57c035fa4d17bd" }
+version = "0.11.2"
+source = { git = "https://github.com/DrudgeCAS/drudge.git?rev=master#de93861f007b4381f083057602b78596a54fede1" }
 dependencies = [
     { name = "dummyrdd" },
+    { name = "ipykernel" },
     { name = "ipython" },
     { name = "jinja2" },
     { name = "pyspark" },


### PR DESCRIPTION
`pyproject.toml` declares the dependency as `drudge @ git+https://github.com/DrudgeCAS/drudge.git@master`, but `uv.lock` pinned a specific revision, `d6e34ab`, drudge 0.11.0. Nothing had refreshed that pin, so the test suite here has not been running against current drudge.

Everything merged into libcanon since then was therefore invisible here, including the three wrong-answer canonicalization fixes that went into libcanon 0.1.3:

- DrudgeCAS/libcanon#13, the orbit relation in `Eldag_coset::form_orbits` was not closed
- DrudgeCAS/libcanon#15, a left-multiplied coset was labelled by the image instead of the pre-image
- DrudgeCAS/libcanon#18, the automorphism chain returned by `canon_string` was not rebuilt

This moves the pin to `93098b4`, **drudge 0.11.3**, which is the first release carrying libcanon 0.1.3. So it picks up the chain-rebuild guard from DrudgeCAS/libcanon#21 as well, not only the correctness fixes.

The test suite passes on the refreshed pin: 30 passed, 2 xfailed, matching the expected result recorded in the contributor instructions. The two xfails are unchanged, so the canonicalization fixes do not on their own resolve `test_factorization_needing_canonicalization`.

Dependabot will keep the pin current from here, since the `uv` ecosystem is already configured.