### PR TITLE
test: State plainly that effective T is not discovered

### DIFF
--- a/tests/opt_cc_test.py
+++ b/tests/opt_cc_test.py
@@ -80,15 +80,14 @@ def test_ccsd_singles_terms(parthole_drudge):
     assert len(eval_seq) == 4
 
 
-def test_ccsd_energy(parthole_drudge):
-    """Test discovery of effective T in CCSD energy equation.
+def _optimize_ccsd_energy(dr):
+    """Optimize the CCSD energy equation with both contraction strategies.
 
-    The purpose of this test is the capability of using locally non-optimal
-    contractions in the final summation optimization.  The equation is not CCSD
-    energy equation exactly.
+    The equation is not the CCSD energy equation exactly.  Both evaluations
+    are checked for correctness here.  The costs are returned, the traversing
+    one first, then the locally optimal one.
     """
 
-    dr = parthole_drudge
     p = dr.names
 
     a, b = p.V_dumms[:2]
@@ -107,16 +106,47 @@ def test_ccsd_energy(parthole_drudge):
 
     assert verify_eval_seq(trav_eval_seq, targets)
     assert len(trav_eval_seq) == 2
-    trav_cost = get_flop_cost(trav_eval_seq)
 
     opt_eval_seq = optimize(
         targets, substs={p.nv: p.no * 10}, contr_strat=ContrStrat.OPT
     )
     assert verify_eval_seq(opt_eval_seq, targets)
     assert len(opt_eval_seq) == 2
-    opt_cost = get_flop_cost(opt_eval_seq)
 
-    assert (opt_cost - trav_cost).xreplace({p.no: 1, p.nv: 10}) >= 0
+    return get_flop_cost(trav_eval_seq), get_flop_cost(opt_eval_seq)
+
+
+def test_ccsd_energy(parthole_drudge):
+    """Test optimization of the CCSD energy equation.
+
+    Both strategies have to reach a correct evaluation in two steps.  Whether
+    the traversing strategy actually finds the cheaper one is a separate
+    question, checked in the test below.
+    """
+
+    _optimize_ccsd_energy(parthole_drudge)
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    'Effective T is not discovered.  The traversing strategy does offer the '
+    'right parenthesization, but the summation optimization declines it.  '
+    'See https://github.com/DrudgeCAS/gristmill/issues/31'
+))
+def test_ccsd_energy_discovers_effective_t(parthole_drudge):
+    """Test discovery of effective T in CCSD energy equation.
+
+    The purpose of this test is the capability of using locally non-optimal
+    contractions in the final summation optimization.  Keeping the traversed
+    parenthesizations should let the effective T be found, which is cheaper
+    than anything reachable from the locally optimal contraction alone.
+    """
+
+    dr = parthole_drudge
+    p = dr.names
+
+    trav_cost, opt_cost = _optimize_ccsd_energy(dr)
+
+    assert (opt_cost - trav_cost).xreplace({p.no: 1, p.nv: 10}) > 0
 
 
 def test_ccsd_doubles(parthole_drudge):


### PR DESCRIPTION
Follows up #31. This does not fix the optimizer, it stops the test from hiding the problem.

## The assertion could not fail

`test_ccsd_energy` asserted that the traversing strategy beats the locally optimal one:

```python
assert (opt_cost - trav_cost).xreplace({p.no: 1, p.nv: 10}) > 0
```

That was relaxed to `>= 0` in 8391994 last November. Since gristmill now returns exactly the same evaluation for every strategy, the difference is exactly `0` and the assertion passes no matter what. The capability the test is named after went missing with no signal at all.

## The assertion was asking for something reachable

Written out by hand, effective T is both correct and cheaper:

```
gristmill  : 4*no**2*nv**2 + 2*no*nv + 1  ->  421   at no=1, nv=10
effective T: 4*no**2*nv**2                ->  400
verified   : True
```

So `> 0` was right, and restoring it is not wishful.

## What this does

Splits the test in two.

- `test_ccsd_energy` keeps the parts that still hold: both strategies reach a correct evaluation in two steps. Ordinary passing test.
- `test_ccsd_energy_discovers_effective_t` carries the cost comparison, back at `> 0`, under `xfail(strict=True)` pointing at #31.

A whole-test xfail would have been simpler but worse: it would also stop guarding `verify_eval_seq` and the two-step length, both of which currently work and would then be free to break unnoticed. The shared setup moved into a helper so neither copy drifts.

The strict marker means this flips to XPASS, and so fails the suite, the moment the summation optimization is fixed. Nobody has to remember to come back and change it.

## Seed stability

Checked over 16 `PYTHONHASHSEED` values: the xfail never turns into an XPASS. Worth checking explicitly, since the optimizer is not deterministic in general, also noted in #31.

Suite: 6 passed, 1 xfailed in this file.