### PR TITLE
fix: Make the dimension chunks independent of the hash seed

### DIFF
--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2690,11 +2690,20 @@ class _Optimizer:
             continue
 
         # The factors with each dimension.
+        #
+        # The dimensions are looped over in their own order here, rather than
+        # in the order the symbols come out of the factor.  ``atoms`` gives a
+        # set, which iterates differently from run to run, and that order is
+        # inherited by everything below: the order the chunks are built in, and
+        # within a chunk the order of its dimensions, which ends up as the
+        # index order of the intermediates.  Taking it from a set makes the
+        # whole optimization depend on the hash seed.
         factors_with = collections.defaultdict(list)
         for i, v in enumerate(factors):
-            for j in v.atoms(Symbol):
-                if j in dumm2dim:
-                    factors_with[dumm2dim[j]].append(i)
+            symbs = v.atoms(Symbol)
+            for j, dim in dumm2dim.items():
+                if j in symbs:
+                    factors_with[dim].append(i)
                 continue
             continue
 

--- a/tests/opt_matrix_test.py
+++ b/tests/opt_matrix_test.py
@@ -9,7 +9,7 @@ tested here.
 
 import pytest
 from drudge import Range, Drudge
-from sympy import symbols, IndexedBase
+from sympy import symbols, Symbol, IndexedBase
 
 from gristmill import optimize, verify_eval_seq, get_flop_cost
 
@@ -371,7 +371,10 @@ def test_disconnected_outer_product_factorization(three_ranges):
     assert leading_cost == 4 * m ** 2
 
 
-@pytest.mark.xfail(reason='TODO: Needs investigation')
+@pytest.mark.xfail(reason=(
+    'The common Z is not factored out, so a single step comes back where two '
+    'are wanted.  See https://github.com/DrudgeCAS/gristmill/issues/31'
+))
 def test_factorization_needing_canonicalization(three_ranges):
     """Test a simple factorization needing canonicalization.
 


### PR DESCRIPTION
Fixes the reproducibility half of #31.

## The optimizer gave a different answer every run

Fingerprinting the evaluation sequences gristmill returns for the CCSD energy equation, over eight `PYTHONHASHSEED` values:

| | distinct results over 8 seeds |
|---|---|
| before | **8** |
| after | **1** |

Not merely different dummy names. On a two-term factorization,

```python
e = A[i, j] * X[i, j] + A[i, j] * y[i] * z[j]
```

the optimizer found the factored form, `4*n**2`, on 11 of 20 seeds, and the locally optimal one, `4*n**2 + 2*n + 1`, on the other 9. A real difference in the answer.

Python randomizes the hash seed on every run and pytest does not pin it, so nothing here was reproducible from one run to the next.

## Cause

`_optimize_prod` built its map from dimensions to the factors involving them by looping over a set:

```python
for i, v in enumerate(factors):
    for j in v.atoms(Symbol):          # a set
        if j in dumm2dim:
            factors_with[dumm2dim[j]].append(i)
```

That order propagates the whole way down:

1. it sets the insertion order of `factors_with`,
2. which sets the insertion order of `involv_dims`,
3. which fixes both the order the dimension chunks are built in and the order of the dimensions *within* each chunk,
4. and `_get_orig_dims` reads the dimensions back out in that order, where it becomes the index order of the intermediates.

`dim_chunks.sort()` does not repair step 3. `Tuple4Cmp` compares on its first element alone, so two chunks of the same category and size keep whatever relative order they were inserted in.

The visible symptom was the same intermediate appearing under two different index orders in the constriction graph, `Interm2[i, j]` in one term and `Interm2[j, i]` in the other, so the shared factor became two vertices instead of one and no biclique covering both terms existed.

## Fix

Loop over the dimensions in their own order rather than over the factor's symbols. That is deterministic, and it is also the natural order, so the dimensions within a chunk come out sorted without a separate sort.

## Also in here

`tests/opt_matrix_test.py` uses `Symbol` but imports only `symbols`. `test_factorization_needing_canonicalization` has been dying on `NameError: name 'Symbol' is not defined` before reaching any of its assertions, which its xfail mark hid entirely. One line to import it, and the reason string updated to say what the test actually fails on now, which is that the common `Z` is not factored out.

It is a test-file fix rather than part of the determinism change, but leaving a knowingly dead test in place while working next to it seemed worse than the small scope increase.

## What this does not fix

The declined biclique, the other half of #31. Both xfails in `opt_matrix_test.py` still fail, now deterministically and for their real reasons, and `test_ccsd_energy` still gives a difference of exactly `0`.

Suite unchanged: 30 passed, 2 xfailed, and identical results over 10 seeds.