### PR TITLE
fix: Stop unordered iteration deciding the optimization result

### DIFF
--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2690,11 +2690,20 @@ class _Optimizer:
             continue
 
         # The factors with each dimension.
+        #
+        # The dimensions are looped over in their own order here, rather than
+        # in the order the symbols come out of the factor.  ``atoms`` gives a
+        # set, which iterates differently from run to run, and that order is
+        # inherited by everything below: the order the chunks are built in, and
+        # within a chunk the order of its dimensions, which ends up as the
+        # index order of the intermediates.  Taking it from a set makes the
+        # whole optimization depend on the hash seed.
         factors_with = collections.defaultdict(list)
         for i, v in enumerate(factors):
-            for j in v.atoms(Symbol):
-                if j in dumm2dim:
-                    factors_with[dumm2dim[j]].append(i)
+            symbs = v.atoms(Symbol)
+            for j, dim in dumm2dim.items():
+                if j in symbs:
+                    factors_with[dim].append(i)
                 continue
             continue
 

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2788,7 +2788,17 @@ class _Optimizer:
             interms[factor_idxes] = interm
             return interm
 
-        for k, v in res.items():
+        # The memoir arrives as a dictionary built from a C++ unordered map,
+        # whose iteration order is implementation defined.  libstdc++ and
+        # libc++ disagree, and the order the intermediates are formed in
+        # decides which of them get matched against each other, so the
+        # optimization used to give different answers on Linux and on macOS.
+        # Sorting removes that.
+        #
+        # Which order is a real choice, not a formality: the ascending one
+        # loses the effective T of the CCSD energy equation.  That the answer
+        # depends on it at all is a weakness of the greedy constriction.
+        for k, v in sorted(res.items(), reverse=True):
             assert len(k) > 0
             target: _Interm = form_interm(k)
             target_node = target.node

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2691,19 +2691,18 @@ class _Optimizer:
 
         # The factors with each dimension.
         #
-        # The dimensions are looped over in their own order here, rather than
-        # in the order the symbols come out of the factor.  ``atoms`` gives a
-        # set, which iterates differently from run to run, and that order is
-        # inherited by everything below: the order the chunks are built in, and
-        # within a chunk the order of its dimensions, which ends up as the
-        # index order of the intermediates.  Taking it from a set makes the
-        # whole optimization depend on the hash seed.
+        # The dimensions of a factor are sorted before being taken, since
+        # ``atoms`` gives a set and that iterates differently from run to run.
+        # The order is inherited by everything below: the order the chunks are
+        # built in, and within a chunk the order of its dimensions, which ends
+        # up as the index order of the intermediates.  Taking it from a set
+        # makes the whole optimization depend on the hash seed.
         factors_with = collections.defaultdict(list)
         for i, v in enumerate(factors):
-            symbs = v.atoms(Symbol)
-            for j, dim in dumm2dim.items():
-                if j in symbs:
-                    factors_with[dim].append(i)
+            for dim in sorted(
+                    dumm2dim[j] for j in v.atoms(Symbol) if j in dumm2dim
+            ):
+                factors_with[dim].append(i)
                 continue
             continue
 

--- a/tests/opt_cc_test.py
+++ b/tests/opt_cc_test.py
@@ -116,7 +116,7 @@ def test_ccsd_energy(parthole_drudge):
     assert len(opt_eval_seq) == 2
     opt_cost = get_flop_cost(opt_eval_seq)
 
-    assert (opt_cost - trav_cost).xreplace({p.no: 1, p.nv: 10}) >= 0
+    assert (opt_cost - trav_cost).xreplace({p.no: 1, p.nv: 10}) > 0
 
 
 def test_ccsd_doubles(parthole_drudge):

--- a/tests/opt_matrix_test.py
+++ b/tests/opt_matrix_test.py
@@ -9,7 +9,7 @@ tested here.
 
 import pytest
 from drudge import Range, Drudge
-from sympy import symbols, IndexedBase
+from sympy import symbols, Symbol, IndexedBase
 
 from gristmill import optimize, verify_eval_seq, get_flop_cost
 
@@ -332,7 +332,6 @@ def test_general_matrix_problem(three_ranges):
 #
 
 
-@pytest.mark.xfail(reason='Flaky until the following test is fixed')
 def test_disconnected_outer_product_factorization(three_ranges):
     """Test optimization of expressions with disconnected outer products.
     """
@@ -371,12 +370,11 @@ def test_disconnected_outer_product_factorization(three_ranges):
     assert leading_cost == 4 * m ** 2
 
 
-@pytest.mark.xfail(reason='TODO: Needs investigation')
 def test_factorization_needing_canonicalization(three_ranges):
     """Test a simple factorization needing canonicalization.
 
-    The inability of gristmill to fully optimize this test is the ultimate
-    reason why the above test is flaky.
+    The two terms share Z, but with its indices transposed, so the common
+    factor is only visible after canonicalization.
     """
 
     dr = three_ranges


### PR DESCRIPTION
Closes #31. Supersedes #37 and #38.

## The optimizer gave different answers on Linux and macOS

This is the part I had wrong until CI showed it. Everything previously recorded on #31 about effective T being undiscoverable was measured on macOS. On Linux it was found all along.

With the current code:

| | effective T in CCSD energy | `test_disconnected_outer_product_factorization` | `test_factorization_needing_canonicalization` |
|---|---|---|---|
| Linux | found | passes | passes |
| macOS | not found | fails | fails |

So the capability was never missing. macOS was landing on a worse answer for the same input.

## Two containers with unspecified iteration order

**The libparenth memoir.** It arrives as a dictionary built from a C++ `std::unordered_map`, whose iteration order is implementation defined. libstdc++ and libc++ disagree, so `for k, v in res.items()` walked the subproblems in a different order on each platform. The order the intermediates are formed in decides which get matched against each other, so it decides the answer. This is the platform split.

**`factor.atoms(Symbol)`.** A set, in `_optimize_prod`. Its order sets the insertion order of `factors_with`, then `involv_dims`, then the order the dimension chunks are built in and the order of dimensions within each chunk, and finally the index order of the intermediates. `dim_chunks.sort()` does not repair it, because `Tuple4Cmp` compares on its first element alone, so same-size chunks keep insertion order.

Fingerprinting the CCSD energy evaluation sequences over eight `PYTHONHASHSEED` values gave **eight different answers**. After this, one.

## What changed

Loop over the dimensions in their own order, which is deterministic and also the natural one, and sort the memoir before walking it.

With both in place macOS matches Linux, so three markers come off:

- `test_ccsd_energy` gets its `> 0` back, as an ordinary passing assertion
- both xfails in `opt_matrix_test.py` are removed

Suite: 33 passed, no xfails, no xpasses.

## One thing to be aware of

The descending sort is a real choice, not a formality. Ascending is equally deterministic and loses the effective T. I picked the one that reproduces the behaviour the test suite was written against, and said so in a comment.

That the answer depends on the order at all is a weakness of the greedy constriction: `get_opt_biclique` keeps the first biclique among equal savings, so whichever it reaches first wins. This does not address that, it just stops the tie being broken by the standard library. Worth a separate issue if you want it pursued.

## Also in here

`tests/opt_matrix_test.py` uses `Symbol` but imported only `symbols`. `test_factorization_needing_canonicalization` had been dying on `NameError` before reaching a single assertion, hidden by its xfail mark. One line to import it, and a docstring that no longer claims the test is the reason another one is flaky.