### PR TITLE
fix: Stop vertex numbering deciding which constrictions are found

### DIFF
--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -737,6 +737,35 @@ class _Biclique(typing.NamedTuple):
     constr_graph: '_ConstrGraph'
 
 
+def _biclique_tie_key(biclique: '_Biclique'):
+    """Order two equally profitable bicliques.
+
+    Equal saving happens often, and the greedy loop then has a real choice to
+    make: the two are not interchangeable, since what is left behind for the
+    next round differs.  Deciding it by whichever was reached first makes the
+    whole optimization depend on the order the vertices were numbered in.
+
+    The key here is built from the canonical form of the vertices and from how
+    many terms the biclique covers, neither of which knows anything about
+    vertex numbering.  Covering more terms comes first, since that is the one
+    part of this with an argument behind it: a constriction over more terms
+    removes more of the sum in one step.  The rest is only there to settle the
+    remaining ties the same way every time.
+    """
+
+    infos = dict(biclique.constr_graph.graph.nodes(data='info'))
+
+    def side(part):
+        return tuple(sorted(
+            (str(infos[vert].canon), str(coeff)) for vert, coeff in part
+        ))
+
+    return (
+        -bin(biclique.terms).count('1'),
+        sorted([side(biclique.parts[0]), side(biclique.parts[1])]),
+    )
+
+
 #
 # Cost-related utilities for the Kron-Kerbosch process.
 #
@@ -888,6 +917,21 @@ class _BronKerbosch:
 
         return
 
+    def _canon_order(self, verts):
+        """Put designated vertices in an order fixed by their content.
+
+        The vertex numbers come from the order edges happened to arrive, so
+        looping over them directly makes the search, and with it the result,
+        depend on that order.  The canonical form of a vertex is content, so
+        ordering by it gives the same search whatever the numbering.
+        """
+
+        infos = self._constr_graph.graph.nodes
+        return sorted(
+            verts,
+            key=lambda v: (v.part, str(infos[v.vert]['info'].canon), v.vert)
+        )
+
     def _expand(
             self, subg: _DesVertsWDelta, cand: _DesVerts,
     ):
@@ -923,7 +967,19 @@ class _BronKerbosch:
             i > 0 for i in n_verts
         ) and any(i > 1 for i in n_verts) and curr_saving >= 0
 
-        if if_maximal and if_profitable:
+        # The two parts of a biclique are interchangeable, so each one would
+        # otherwise be generated twice.  Keep only the orientation where the
+        # lowest numbered vertex sits in the first part.  This is decided on
+        # the finished biclique rather than on the pair it was started from,
+        # so that no branch is cut off from a biclique it is responsible for
+        # under the CAND bookkeeping.
+        if_oriented = True
+        if exts[0] == exts[1] and all(i > 0 for i in n_verts):
+            if_oriented = (
+                min(i[0] for i in curr[0]) < min(i[0] for i in curr[1])
+            )
+
+        if if_maximal and if_profitable and if_oriented:
             # If maximal and profitable.
             #
             # if not subg_q:
@@ -965,10 +1021,10 @@ class _BronKerbosch:
             to_loop = {i for i in cand if i.part == 0}
         elif n_verts[1] == 0:
             to_loop = {i for i in cand if i.part == 1}
-            if exts[0] == exts[1]:
-                # First part, first vertex, the vertex
-                exist_vert: int = curr[0][0][0]
-                to_loop = {i for i in to_loop if i.vert > exist_vert}
+            # The orientation used to be forced here, by demanding this vertex
+            # exceed the first part's vertex.  That cut branches which the CAND
+            # bookkeeping had already made responsible for some bicliques, so
+            # those went missing.  It is now decided at the yield instead.
             if self._req_an_opt:
                 to_loop = {i for i in to_loop if subg[i].exc_cost == 0}
             else:
@@ -996,12 +1052,18 @@ class _BronKerbosch:
                     pivots = []
 
         # Designated vertices that can be excluded for each pivot.
-        fqs = (
-            {i for i in subgq[k].keys() if i.part == k.part}
+        fqs = [
+            (k, {i for i in subgq[k].keys() if i.part == k.part})
             for k in pivots
-        )
+        ]
+        # Ties on the pivot are settled by content as well, for the same
+        # reason: `subg` is in the order its vertices were created.
+        fqs = [(self._canon_order([k])[0], v) for k, v in fqs]
         try:
-            excl = max(fqs, key=lambda x: len(x & to_loop))
+            _, excl = max(
+                fqs, key=lambda x: (len(x[1] & to_loop),
+                                    tuple(-ord(c) for c in str(x[0])))
+            )
         except ValueError:
             pass
         else:
@@ -1011,7 +1073,7 @@ class _BronKerbosch:
             to_loop = list(to_loop)
             random.shuffle(to_loop)
 
-        for q_v in to_loop:
+        for q_v in self._canon_order(to_loop):
             q_d = subg[q_v]
             part, vert = q_v.part, q_v.vert
 
@@ -1254,13 +1316,26 @@ class _ConstrGraph:
 
         opt_saving = None
         opt_biclique = None
+        opt_key = None
 
         for biclique in _BronKerbosch(last_step_idxes, self):
 
             saving = biclique.saving
 
             if opt_saving is None or saving > opt_saving:
+                better = True
+            elif saving == opt_saving:
+                # Equally profitable.  Left to itself the first one reached
+                # wins, which makes the result depend on the order the
+                # vertices happened to be numbered in.  Break the tie on the
+                # content instead.
+                better = _biclique_tie_key(biclique) < opt_key
+            else:
+                better = False
+
+            if better:
                 opt_saving = saving
+                opt_key = _biclique_tie_key(biclique)
                 # Make copy only when we need them.
                 parts = biclique.parts
                 assert len(parts) == 2
@@ -1364,6 +1439,7 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
         opt_saving = None
         opt_last_step_idxes = None
         opt_biclique = None
+        opt_key = None
         for last_step_idxes, constr_graph in self.items():
 
             curr_opt_saving, curr_opt_biclique = constr_graph.get_opt_biclique(
@@ -1373,8 +1449,19 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
             if curr_opt_saving is None:
                 continue
 
+            # Same tie as inside a single graph, one level up: the graphs are
+            # walked in the order they were created, so without a tie-break
+            # the winner among equally profitable ones depends on that order.
             if opt_saving is None or curr_opt_saving > opt_saving:
+                better = True
+            elif curr_opt_saving == opt_saving:
+                better = _biclique_tie_key(curr_opt_biclique) < opt_key
+            else:
+                better = False
+
+            if better:
                 opt_saving = curr_opt_saving
+                opt_key = _biclique_tie_key(curr_opt_biclique)
                 opt_last_step_idxes = last_step_idxes
                 opt_biclique = curr_opt_biclique
 

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -757,7 +757,7 @@ def _biclique_tie_key(biclique: '_Biclique'):
 
     def side(part):
         return tuple(sorted(
-            (str(nodes[vert]['info'].canon), str(coeff))
+            (nodes[vert]['info'].canon.sort_key, str(coeff))
             for vert, coeff in part
         ))
 
@@ -970,16 +970,22 @@ class _BronKerbosch:
                     best = gain
         return best
 
-    def _vert_content(self, vert: int) -> str:
+    def _vert_content(self, vert: int):
         """The canonical form of a vertex, as something orderable.
 
         Vertex numbers come from the order edges happened to arrive.  Anything
         in the search that consults them makes the result depend on that order.
         The canonical form is content, so it does not move when the numbering
         does.
+
+        `sort_key` rather than `str`.  A term's string leaves out the range of
+        its summation dummy, and drudge lets two ranges share dummy symbols, so
+        two different vertices can print the same.  Keying on the string would
+        collide them, fall back to the vertex number, and put back exactly the
+        dependence being removed.
         """
 
-        return str(self._constr_graph.graph.nodes[vert]['info'].canon)
+        return self._constr_graph.graph.nodes[vert]['info'].canon.sort_key
 
     def _canon_order(self, verts):
         """Put designated vertices in an order fixed by their content."""
@@ -1032,9 +1038,15 @@ class _BronKerbosch:
         # under the CAND bookkeeping.
         if_oriented = True
         if exts[0] == exts[1] and all(i > 0 for i in n_verts):
+            # `<=` rather than `<`.  The two sides are disjoint in every
+            # reachable case, so this behaves as `<` and keeps one orientation
+            # of the pair.  Were a vertex ever to sit in both sides, `<` would
+            # reject both orientations and lose the biclique outright, while
+            # `<=` admits both, and the two are then the same biclique so the
+            # caller taking the best of them is unharmed.
             if_oriented = (
                 min(self._vert_content(i[0]) for i in curr[0])
-                < min(self._vert_content(i[0]) for i in curr[1])
+                <= min(self._vert_content(i[0]) for i in curr[1])
             )
 
         if if_maximal and if_profitable and if_oriented:
@@ -1124,10 +1136,14 @@ class _BronKerbosch:
                     to_loop = {random.choice(list(to_loop))}
 
         if self._opt.rand_constr:
-            to_loop = list(to_loop)
-            random.shuffle(to_loop)
+            # Deliberately random, so leave the order alone.  Sorting here
+            # would undo the shuffle and quietly turn `rand_constr` off.
+            order = list(to_loop)
+            random.shuffle(order)
+        else:
+            order = self._canon_order(to_loop)
 
-        for q_v in self._canon_order(to_loop):
+        for q_v in order:
             q_d = subg[q_v]
             part, vert = q_v.part, q_v.vert
 

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -753,15 +753,16 @@ def _biclique_tie_key(biclique: '_Biclique'):
     remaining ties the same way every time.
     """
 
-    infos = dict(biclique.constr_graph.graph.nodes(data='info'))
+    nodes = biclique.constr_graph.graph.nodes
 
     def side(part):
         return tuple(sorted(
-            (str(infos[vert].canon), str(coeff)) for vert, coeff in part
+            (str(nodes[vert]['info'].canon), str(coeff))
+            for vert, coeff in part
         ))
 
     return (
-        -bin(biclique.terms).count('1'),
+        -biclique.terms.bit_count(),
         sorted([side(biclique.parts[0]), side(biclique.parts[1])]),
     )
 
@@ -917,19 +918,23 @@ class _BronKerbosch:
 
         return
 
-    def _canon_order(self, verts):
-        """Put designated vertices in an order fixed by their content.
+    def _vert_content(self, vert: int) -> str:
+        """The canonical form of a vertex, as something orderable.
 
-        The vertex numbers come from the order edges happened to arrive, so
-        looping over them directly makes the search, and with it the result,
-        depend on that order.  The canonical form of a vertex is content, so
-        ordering by it gives the same search whatever the numbering.
+        Vertex numbers come from the order edges happened to arrive.  Anything
+        in the search that consults them makes the result depend on that order.
+        The canonical form is content, so it does not move when the numbering
+        does.
         """
 
-        infos = self._constr_graph.graph.nodes
+        return str(self._constr_graph.graph.nodes[vert]['info'].canon)
+
+    def _canon_order(self, verts):
+        """Put designated vertices in an order fixed by their content."""
+
         return sorted(
             verts,
-            key=lambda v: (v.part, str(infos[v.vert]['info'].canon), v.vert)
+            key=lambda v: (v.part, self._vert_content(v.vert), v.vert)
         )
 
     def _expand(
@@ -976,7 +981,8 @@ class _BronKerbosch:
         if_oriented = True
         if exts[0] == exts[1] and all(i > 0 for i in n_verts):
             if_oriented = (
-                min(i[0] for i in curr[0]) < min(i[0] for i in curr[1])
+                min(self._vert_content(i[0]) for i in curr[0])
+                < min(self._vert_content(i[0]) for i in curr[1])
             )
 
         if if_maximal and if_profitable and if_oriented:
@@ -1057,13 +1063,12 @@ class _BronKerbosch:
             for k in pivots
         ]
         # Ties on the pivot are settled by content as well, for the same
-        # reason: `subg` is in the order its vertices were created.
-        fqs = [(self._canon_order([k])[0], v) for k, v in fqs]
+        # reason: `subg` is in the order its vertices were created.  Ordering
+        # the candidates by content first is enough, since `max` keeps the
+        # first of any equals.
+        fqs.sort(key=lambda x: (x[0].part, self._vert_content(x[0].vert)))
         try:
-            _, excl = max(
-                fqs, key=lambda x: (len(x[1] & to_loop),
-                                    tuple(-ord(c) for c in str(x[0])))
-            )
+            _, excl = max(fqs, key=lambda x: len(x[1] & to_loop))
         except ValueError:
             pass
         else:

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -753,12 +753,11 @@ def _biclique_tie_key(biclique: '_Biclique'):
     remaining ties the same way every time.
     """
 
-    nodes = biclique.constr_graph.graph.nodes
+    vert_key = biclique.constr_graph.vert_key
 
     def side(part):
         return tuple(sorted(
-            (nodes[vert]['info'].canon.sort_key, str(coeff))
-            for vert, coeff in part
+            (vert_key(vert), str(coeff)) for vert, coeff in part
         ))
 
     return (
@@ -915,6 +914,19 @@ class _BronKerbosch:
 
         assert len(subg) > 0
 
+        # The rank of each vertex in content order.  The search orders its
+        # candidates and orients its bicliques by this rank, so it consults
+        # nothing that follows the order edges arrived in.  Ranks are small
+        # integers, so the many comparisons in the search stay cheap; the sort
+        # keys behind them are computed once per vertex and cached in the
+        # graph.
+        vert_key = self._constr_graph.vert_key
+        self._rank = {
+            vert: rank for rank, vert in enumerate(sorted(
+                {i.vert for i in subg}, key=lambda v: (vert_key(v), v)
+            ))
+        }
+
         # For random constriction, if a biclique has ever been yielded.
         self._yielded = False
         yield from self._expand(subg, set(subg.keys()))
@@ -970,30 +982,11 @@ class _BronKerbosch:
                     best = gain
         return best
 
-    def _vert_content(self, vert: int):
-        """The canonical form of a vertex, as something orderable.
-
-        Vertex numbers come from the order edges happened to arrive.  Anything
-        in the search that consults them makes the result depend on that order.
-        The canonical form is content, so it does not move when the numbering
-        does.
-
-        `sort_key` rather than `str`.  A term's string leaves out the range of
-        its summation dummy, and drudge lets two ranges share dummy symbols, so
-        two different vertices can print the same.  Keying on the string would
-        collide them, fall back to the vertex number, and put back exactly the
-        dependence being removed.
-        """
-
-        return self._constr_graph.graph.nodes[vert]['info'].canon.sort_key
-
     def _canon_order(self, verts):
         """Put designated vertices in an order fixed by their content."""
 
-        return sorted(
-            verts,
-            key=lambda v: (v.part, self._vert_content(v.vert), v.vert)
-        )
+        rank = self._rank
+        return sorted(verts, key=lambda v: (v.part, rank[v.vert]))
 
     def _expand(
             self, subg: _DesVertsWDelta, cand: _DesVerts,
@@ -1044,9 +1037,10 @@ class _BronKerbosch:
             # reject both orientations and lose the biclique outright, while
             # `<=` admits both, and the two are then the same biclique so the
             # caller taking the best of them is unharmed.
+            rank = self._rank
             if_oriented = (
-                min(self._vert_content(i[0]) for i in curr[0])
-                <= min(self._vert_content(i[0]) for i in curr[1])
+                min(rank[i[0]] for i in curr[0])
+                <= min(rank[i[0]] for i in curr[1])
             )
 
         if if_maximal and if_profitable and if_oriented:
@@ -1100,24 +1094,28 @@ class _BronKerbosch:
 
         # to_loop need to be eagerly evaluated for avoiding complication with
         # the mutation of cand during the loop.
-        #
-        # The pivot exclusion that used to follow this is gone.  It rests on an
-        # exchange argument: a maximal biclique avoiding every neighbour of the
-        # pivot could have taken the pivot in, so it was not maximal.
-        # Maximality here is having no augmentation that raises the saving, and
-        # taking a vertex in can lower the saving, so the argument does not
-        # hold, and profitable bicliques were being dropped.  The bound above
-        # prunes on something that is true instead, and on the shapes measured
-        # it prunes harder as well.
 
+        rand_constr = self._opt.rand_constr
         if n_verts[0] == 0:
             to_loop = {i for i in cand if i.part == 0}
         elif n_verts[1] == 0:
             to_loop = {i for i in cand if i.part == 1}
-            # The orientation used to be forced here, by demanding this vertex
-            # exceed the first part's vertex.  That cut branches which the CAND
-            # bookkeeping had already made responsible for some bicliques, so
-            # those went missing.  It is now decided at the yield instead.
+            if exts[0] == exts[1] and not rand_constr:
+                # Take the second vertex only from above the first in content
+                # rank, so that each biclique is built in one orientation
+                # only.  This is sound because the first-part vertices are
+                # looped in ascending rank: the branch of a biclique's lowest
+                # ranked vertex runs before any other of its vertices has
+                # been dropped from CAND, and there every other vertex of the
+                # biclique ranks above it.  It used to key on the vertex
+                # numbers, whose order follows the arrival of edges, and the
+                # first-part loop did not follow that order, so branches were
+                # cut that the CAND bookkeeping had already made responsible
+                # for some bicliques.  Under random constriction the loop is
+                # shuffled, and the check at the yield does this job alone.
+                rank = self._rank
+                first_rank = rank[curr[0][0][0]]
+                to_loop = {i for i in to_loop if rank[i.vert] > first_rank}
             if self._req_an_opt:
                 to_loop = {i for i in to_loop if subg[i].exc_cost == 0}
         else:
@@ -1134,6 +1132,41 @@ class _BronKerbosch:
                 }
                 if cut_full:
                     to_loop = {random.choice(list(to_loop))}
+
+            # Pivoting, restricted to where its argument holds.  The pivot u
+            # augments the current biclique with positive saving.  Adding to
+            # the current biclique only vertices from the same part as u,
+            # each of which can still join once u has, leaves u able to join
+            # with that same positive saving, so no such biclique is maximal
+            # and the branches trying those vertices first can be skipped.
+            # The argument needs every biclique this branch is responsible
+            # for to be built from such vertices alone.  Candidates outside
+            # `to_loop`, those with negative saving now, may still join
+            # later, and a biclique taking one of them in need not be
+            # improvable by u.  So a pivot is only used when every such
+            # candidate is also a same-part vertex compatible with u.  At the
+            # second-vertex level the other part is always available, so no
+            # pivot is used there.
+            #
+            # The general rule from the thesis pivots from every vertex with
+            # positive saving, and lost profitable bicliques for exactly this
+            # reason (issue #43).
+            if not rand_constr and not cut_full:
+                outside = cand - to_loop
+                excl = None
+                excl_size = 0
+                for k, v in subg.items():
+                    if not v.saving > 0:
+                        continue
+                    fq = {i for i in subgq[k] if i.part == k.part}
+                    if not outside <= fq:
+                        continue
+                    size = len(fq & to_loop)
+                    if size > excl_size:
+                        excl = fq
+                        excl_size = size
+                if excl is not None:
+                    to_loop -= excl
 
         if self._opt.rand_constr:
             # Deliberately random, so leave the order alone.  Sorting here
@@ -1307,6 +1340,11 @@ class _ConstrGraph:
         self._verts = {}  # From canonicalized factor to the vertex number.
         self.terms = 0
 
+        # The sort key of the canonical content of each vertex, filled on
+        # demand.  Computing it is not cheap and the search asks for it a
+        # great many times.
+        self._vert_keys = {}
+
         # The optimal biclique in the current graph.  None when it is not yet
         # determined, False when it is determined that there is no profitable
         # biclique in the current graph.
@@ -1319,6 +1357,23 @@ class _ConstrGraph:
         return (
             (i, j) for i, j in self.graph.nodes(data='info')
         )
+
+    def vert_key(self, vert: int):
+        """The sort key of the canonical content of a vertex.
+
+        Vertex numbers come from the order edges happened to arrive.  Anything
+        in the search that consults them makes the result depend on that order.
+        The canonical content does not move when the numbering does, and its
+        `sort_key` orders it.  `sort_key` rather than `str`: a term's string
+        leaves out the range of its summation dummy, and drudge lets two ranges
+        share dummy symbols, so two different vertices can print the same.
+        """
+        keys = self._vert_keys
+        if vert in keys:
+            return keys[vert]
+        key = self.graph.nodes[vert]['info'].canon.sort_key
+        keys[vert] = key
+        return key
 
     def add_edge(
             self, node_infos: typing.Tuple[_VertInfo, _VertInfo],

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -932,6 +932,15 @@ class _BronKerbosch:
         # pins down.  Adding vertices does shift the ranks themselves, but
         # not the order of the vertices already present, which is what the
         # comparisons read.
+        #
+        # What this does not buy: the order is still one particular order,
+        # and the key ends in the amplitude, which carries the tensors' own
+        # names.  Renaming the tensors of a problem therefore reorders the
+        # vertices and can land the greedy search somewhere else.  So the
+        # answer is a function of the mathematics and of the names given to
+        # the tensors, rather than of the order the graph was built in.  The
+        # names are at least the user's to choose and stay put from run to
+        # run, which the numbering did not.
         vert_key = self._constr_graph.vert_key
         self._rank = {
             vert: rank for rank, vert in enumerate(sorted(

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -1024,11 +1024,17 @@ class _BronKerbosch:
         ) and any(i > 1 for i in n_verts) and curr_saving >= 0
 
         # The two parts of a biclique are interchangeable, so each one would
-        # otherwise be generated twice.  Keep only the orientation where the
-        # lowest numbered vertex sits in the first part.  This is decided on
-        # the finished biclique rather than on the pair it was started from,
-        # so that no branch is cut off from a biclique it is responsible for
-        # under the CAND bookkeeping.
+        # otherwise be generated twice.  Keep only the orientation whose first
+        # part holds the vertex lowest in content rank.  The candidates for
+        # the second vertex are already restricted the same way, which is what
+        # keeps the search from walking both orientations; this is the check
+        # that the finished biclique has to pass, and it is the only one under
+        # random constriction, where the loop is shuffled and that restriction
+        # is not applied.
+        #
+        # Content rank, not the vertex number.  Numbers follow the order edges
+        # arrived, so an orientation rule reading them decides which bicliques
+        # are emitted at all on an accident of the input order.
         if_oriented = True
         if exts[0] == exts[1] and all(i > 0 for i in n_verts):
             # `<=` rather than `<`.  The two sides are disjoint in every
@@ -1447,6 +1453,9 @@ class _ConstrGraph:
 
             saving = biclique.saving
 
+            # The key is only needed on a tie, and it is not cheap, so it is
+            # computed at most once for each biclique and reused below.
+            key = None
             if opt_saving is None or saving > opt_saving:
                 better = True
             elif saving == opt_saving:
@@ -1454,13 +1463,16 @@ class _ConstrGraph:
                 # wins, which makes the result depend on the order the
                 # vertices happened to be numbered in.  Break the tie on the
                 # content instead.
-                better = _biclique_tie_key(biclique) < opt_key
+                key = _biclique_tie_key(biclique)
+                better = key < opt_key
             else:
                 better = False
 
             if better:
                 opt_saving = saving
-                opt_key = _biclique_tie_key(biclique)
+                opt_key = key if key is not None else _biclique_tie_key(
+                    biclique
+                )
                 # Make copy only when we need them.
                 parts = biclique.parts
                 assert len(parts) == 2
@@ -1577,16 +1589,21 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
             # Same tie as inside a single graph, one level up: the graphs are
             # walked in the order they were created, so without a tie-break
             # the winner among equally profitable ones depends on that order.
+            # As there, the key is built at most once for each graph.
+            key = None
             if opt_saving is None or curr_opt_saving > opt_saving:
                 better = True
             elif curr_opt_saving == opt_saving:
-                better = _biclique_tie_key(curr_opt_biclique) < opt_key
+                key = _biclique_tie_key(curr_opt_biclique)
+                better = key < opt_key
             else:
                 better = False
 
             if better:
                 opt_saving = curr_opt_saving
-                opt_key = _biclique_tie_key(curr_opt_biclique)
+                opt_key = key if key is not None else _biclique_tie_key(
+                    curr_opt_biclique
+                )
                 opt_last_step_idxes = last_step_idxes
                 opt_biclique = curr_opt_biclique
 

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -824,6 +824,11 @@ class _VertGross(typing.Dict[typing.Tuple[int, int], typing.Tuple[Size, Size]]):
         """Initialize the dictionary."""
         self._cost_coeffs = _get_cost_coeffs(last_step_idxes)
 
+    @property
+    def cost_coeffs(self) -> '_CostCoeffs':
+        """The cost coefficients behind the gross savings."""
+        return self._cost_coeffs
+
     def __missing__(self, key):
         """Compute the gross savings for new keys."""
         assert len(key) == 2
@@ -886,6 +891,11 @@ class _BronKerbosch:
         # The set of terms currently in the biclique.
         self._terms = 0
 
+        # The best saving yielded so far.  The caller only wants the most
+        # profitable biclique, so a branch that cannot beat this is not worth
+        # descending into.  Kept as None until something has been yielded.
+        self._best_saving = None
+
         # Gross saving of new vertices.
         self._vert_gross: _VertGross = _VertGross(last_step_idxes)
 
@@ -917,6 +927,48 @@ class _BronKerbosch:
         assert self._leading_coeff is None
 
         return
+
+    def _reach_bound(self, n_verts, cand) -> Size:
+        """The most the saving could still rise from here.
+
+        The saving of a biclique is its gross saving less the excess costs of
+        the edges it takes in.  Excess costs are never negative, since a
+        candidate form cannot be cheaper than the term's own optimum, so
+        ignoring the excess of edges not yet taken can only overestimate.  That
+        makes this an upper bound, and pruning on it cannot drop a biclique
+        that would have been profitable.
+
+        The gross saving at sizes (M, N) is
+
+            final * (M * N - 1) - preps[0] * (M - 1) - preps[1] * (N - 1)
+
+        which follows from the marginal saving `_VertGross` already computes.
+        Its increase on going to (M + i, N + j) is
+
+            final * (M * j + N * i + i * j) - preps[0] * i - preps[1] * j
+
+        That is bilinear in i and j, so over the rectangle of reachable sizes
+        it is largest at one of the four corners, and four evaluations settle
+        it however many candidates there are.
+        """
+
+        coeffs = self._vert_gross.cost_coeffs
+        final, preps = coeffs.final, coeffs.preps
+        curr_l, curr_r = n_verts
+
+        avail_l = sum(1 for i in cand if i.part == 0)
+        avail_r = sum(1 for i in cand if i.part == 1)
+
+        best = None
+        for i in (0, avail_l):
+            for j in (0, avail_r):
+                gain = (
+                    final * (curr_l * j + curr_r * i + i * j)
+                    - preps[0] * i - preps[1] * j
+                )
+                if best is None or gain > best:
+                    best = gain
+        return best
 
     def _vert_content(self, vert: int) -> str:
         """The canonical form of a vertex, as something orderable.
@@ -992,6 +1044,8 @@ class _BronKerbosch:
             #    yield Q[:]
             #
             self._yielded = True
+            if self._best_saving is None or curr_saving > self._best_saving:
+                self._best_saving = curr_saving
             yield _Biclique(
                 parts=curr, leading_coeff=self._leading_coeff,
                 terms=self._terms, saving=curr_saving,
@@ -999,6 +1053,20 @@ class _BronKerbosch:
             )
 
         if self._yielded and self._opt.rand_constr:
+            return
+
+        # Branch and bound.  If nothing reachable from here can beat what has
+        # already been found, and cannot be profitable either, there is no
+        # point descending.  Unlike pivoting this is sound: the bound is an
+        # overestimate, so a branch it drops held nothing worth having.
+        #
+        # The comparison is strict, so bicliques that merely tie with the best
+        # so far are still generated.  The caller breaks those ties on content,
+        # and it can only do that if it sees them.
+        reach = curr_saving + self._reach_bound(n_verts, cand)
+        if reach < 0:
+            return
+        if self._best_saving is not None and reach < self._best_saving:
             return
 
         # The quadratic loop.
@@ -1019,10 +1087,17 @@ class _BronKerbosch:
         #
 
         # to_loop need to be eagerly evaluated for avoiding complication with
-        # the mutation of cand during the loop and the set operations for
-        # pivoting.
+        # the mutation of cand during the loop.
+        #
+        # The pivot exclusion that used to follow this is gone.  It rests on an
+        # exchange argument: a maximal biclique avoiding every neighbour of the
+        # pivot could have taken the pivot in, so it was not maximal.
+        # Maximality here is having no augmentation that raises the saving, and
+        # taking a vertex in can lower the saving, so the argument does not
+        # hold, and profitable bicliques were being dropped.  The bound above
+        # prunes on something that is true instead, and on the shapes measured
+        # it prunes harder as well.
 
-        pivots: typing.Iterable[_DesVert] = []
         if n_verts[0] == 0:
             to_loop = {i for i in cand if i.part == 0}
         elif n_verts[1] == 0:
@@ -1033,18 +1108,10 @@ class _BronKerbosch:
             # those went missing.  It is now decided at the yield instead.
             if self._req_an_opt:
                 to_loop = {i for i in to_loop if subg[i].exc_cost == 0}
-            else:
-                gross = self._vert_gross[(1, 1)][1]
-                pivots = (
-                    k for k, v in subg.items()
-                    if k.part == 1 and gross - v.exc_cost >= 0
-                )
         else:
             to_loop = {i for i in cand if subg[i].saving >= 0}
             if len(to_loop) == 0:
                 return
-
-            pivots = (k for k, v in subg.items() if v.saving > 0)
 
             cut_greedy = 0 <= self._greedy_cutoff <= depth
             cut_full = 0 <= self._drop_cutoff <= depth
@@ -1055,24 +1122,6 @@ class _BronKerbosch:
                 }
                 if cut_full:
                     to_loop = {random.choice(list(to_loop))}
-                    pivots = []
-
-        # Designated vertices that can be excluded for each pivot.
-        fqs = [
-            (k, {i for i in subgq[k].keys() if i.part == k.part})
-            for k in pivots
-        ]
-        # Ties on the pivot are settled by content as well, for the same
-        # reason: `subg` is in the order its vertices were created.  Ordering
-        # the candidates by content first is enough, since `max` keeps the
-        # first of any equals.
-        fqs.sort(key=lambda x: (x[0].part, self._vert_content(x[0].vert)))
-        try:
-            _, excl = max(fqs, key=lambda x: len(x[1] & to_loop))
-        except ValueError:
-            pass
-        else:
-            to_loop -= excl
 
         if self._opt.rand_constr:
             to_loop = list(to_loop)

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2960,9 +2960,13 @@ class _Optimizer:
         # optimization used to give different answers on Linux and on macOS.
         # Sorting removes that.
         #
-        # Which order is a real choice, not a formality: the ascending one
-        # loses the effective T of the CCSD energy equation.  That the answer
-        # depends on it at all is a weakness of the greedy constriction.
+        # The direction used to matter: the ascending walk lost the effective
+        # T of the CCSD energy equation, because the biclique search read the
+        # vertex numbers, which follow this walk.  The search no longer reads
+        # them, and the walk order is now only a reproducibility measure: the
+        # test suite and the generated problem sets give the same answers
+        # under either direction and under random permutations of the walk.
+        # The descending direction is kept as it is, since nothing hangs on it.
         for k, v in sorted(res.items(), reverse=True):
             assert len(k) > 0
             target: _Interm = form_interm(k)

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -920,6 +920,18 @@ class _BronKerbosch:
         # integers, so the many comparisons in the search stay cheap; the sort
         # keys behind them are computed once per vertex and cached in the
         # graph.
+        #
+        # What the search actually asks is never a vertex's rank on its own,
+        # only comparisons: does this candidate come before that one, does
+        # this part hold the earlier vertex.  Under content, the answer for
+        # any two vertices is fixed by those two alone.  Under the numbering
+        # it depended on everything inserted before both, so a term elsewhere
+        # in the sum, sharing no factor and unable to join any biclique here,
+        # still shifted the numbers and could change what was chosen.  That
+        # is the property `test_unrelated_term_does_not_disturb_the_rest`
+        # pins down.  Adding vertices does shift the ranks themselves, but
+        # not the order of the vertices already present, which is what the
+        # comparisons read.
         vert_key = self._constr_graph.vert_key
         self._rank = {
             vert: rank for rank, vert in enumerate(sorted(

--- a/tests/opt_misc_test.py
+++ b/tests/opt_misc_test.py
@@ -57,6 +57,64 @@ def test_summation_shared_by_four_factors(simple_drudge):
     assert all(i == costs[0] for i in costs)
 
 
+def test_constriction_over_an_outer_product(simple_drudge):
+    """Test factoring a common tensor out over an outer product.
+
+    Both terms share A, so the good evaluation forms X + y z once and contracts
+    it with A, costing 4 n^2.  Taking the locally optimal contraction of the
+    second term instead gives 4 n^2 + 2 n + 1.
+
+    The optimizer used to return either, depending on the order the vertices of
+    the constriction graph happened to be numbered in, which followed the order
+    a C++ unordered map was iterated.  See issue #43.
+    """
+
+    dr = simple_drudge
+    n = dr.n
+    a, b = dr.ds[:2]
+
+    A, X = IndexedBase('A'), IndexedBase('X')
+    y, z = IndexedBase('y'), IndexedBase('z')
+
+    targets = [dr.define_einst(
+        Symbol('e'), A[a, b] * X[a, b] + A[a, b] * y[a] * z[b])]
+
+    eval_seq = optimize(targets)
+
+    assert verify_eval_seq(eval_seq, targets)
+    assert get_flop_cost(eval_seq) == 4 * n ** 2
+
+
+def test_constriction_over_three_terms(simple_drudge):
+    """Test a constriction that has to take all three terms at once.
+
+    Every term has both X and y, so the good evaluation forms the vector
+    z - u + 2 y, contracts X with y once, and puts the two together, costing
+    2 n^2 + 4 n.  Stopping after a constriction over only two of the terms
+    leaves a second matrix-vector product and costs 4 n^2 + 4 n.
+
+    Both were reachable before, decided by vertex numbering.  See issue #43.
+    """
+
+    dr = simple_drudge
+    n = dr.n
+    a, b = dr.ds[:2]
+
+    X = IndexedBase('X')
+    y, z, u = (IndexedBase(i) for i in ['y', 'z', 'u'])
+
+    targets = [dr.define_einst(
+        Symbol('e'),
+        X[a, b] * z[a] * y[b]
+        + 2 * X[a, b] * y[a] * y[b]
+        - X[a, b] * u[a] * y[b])]
+
+    eval_seq = optimize(targets)
+
+    assert verify_eval_seq(eval_seq, targets)
+    assert get_flop_cost(eval_seq) == 2 * n ** 2 + 4 * n
+
+
 def test_simple_scalar_optimization(spark_ctx):
     """Test optimization of a simple scalar.
 

--- a/tests/opt_misc_test.py
+++ b/tests/opt_misc_test.py
@@ -115,6 +115,38 @@ def test_constriction_over_three_terms(simple_drudge):
     assert get_flop_cost(eval_seq) == 2 * n ** 2 + 4 * n
 
 
+def test_constriction_search_is_not_pruned_unsoundly(simple_drudge):
+    """Test a constriction the pivot pruning used to throw away.
+
+    All three terms share P and all three involve u, so the good evaluation
+    contracts P once and costs 4 n^2 + 4 n.  Pruning the search by the pivot
+    rule loses that and leaves 5 n^2 + 3 n, which is worse by a whole power of
+    n rather than by a constant.
+
+    The pivot rule assumes taking a vertex into a biclique cannot lower its
+    saving, which is true for ordinary maximal cliques and false here.  See
+    issue #43.
+    """
+
+    dr = simple_drudge
+    n = dr.n
+    a, b = dr.ds[:2]
+
+    P = IndexedBase('P')
+    z, u, w = (IndexedBase(i) for i in ['z', 'u', 'w'])
+
+    targets = [dr.define_einst(
+        Symbol('res'),
+        -P[a, b] * z[a] * u[b]
+        + P[a, b] * u[a] * w[b]
+        + 3 * P[a, b] * w[a] * u[b])]
+
+    eval_seq = optimize(targets)
+
+    assert verify_eval_seq(eval_seq, targets)
+    assert get_flop_cost(eval_seq) == 4 * n ** 2 + 4 * n
+
+
 def test_simple_scalar_optimization(spark_ctx):
     """Test optimization of a simple scalar.
 

--- a/tests/opt_order_test.py
+++ b/tests/opt_order_test.py
@@ -15,7 +15,7 @@ from drudge import Drudge, PartHoleDrudge, Range
 from sympy import symbols, Symbol, IndexedBase, Rational
 
 import gristmill.optimize
-from gristmill import optimize, verify_eval_seq, get_flop_cost
+from gristmill import optimize, verify_eval_seq, get_flop_cost, ContrStrat
 
 _REAL_SORTED = sorted
 
@@ -186,3 +186,55 @@ def test_rand_constr_gives_random_constrictions(spark_ctx):
         seen.add(tuple(str(i) for i in eval_seq))
 
     assert len(seen) > 1
+
+
+def test_unrelated_term_does_not_disturb_the_rest(spark_ctx):
+    """A term sharing nothing with the rest must not change how the rest goes.
+
+    The extra term here shares no tensor with the other three, so it cannot
+    take part in any constriction with them.  Optimizing the two together
+    should therefore cost exactly what optimizing them apart costs, plus the
+    one addition that puts the two scalars together.
+
+    It did not.  The vertices of a constriction graph used to be ordered by a
+    number handed out as edges arrived, so the extra term shifted the numbers
+    of every vertex belonging to the others, and the search read those
+    numbers.  On master the three terms alone come out at ``4 n^2 + 4 n``,
+    while in the presence of the extra term they come out at ``2 n^2 + 4 n``:
+    an unrelated term, by luck, buying a better factorization.
+
+    This pins one instance, not a theorem.  The outer loop is greedy and the
+    branch and bound carries an incumbent, so adding terms can legitimately
+    change what is found.  What it guards is the search reading anything that
+    follows the order the graph happened to be built in.
+    """
+
+    dr = Drudge(spark_ctx)
+    n = symbols('n')
+    r = Range('r', 0, n)
+    dr.set_dumms(r, symbols('a b c d e f g h'))
+    dr.add_default_resolver(r)
+    a, b = symbols('a b')
+
+    x = IndexedBase('X')
+    y, z, u = (IndexedBase(i) for i in ['y', 'z', 'u'])
+    p, q = IndexedBase('P'), IndexedBase('Q')
+
+    core = (
+        x[a, b] * z[a] * y[b]
+        + 2 * x[a, b] * y[a] * y[b]
+        - x[a, b] * u[a] * y[b]
+    )
+    extra = p[a, b] * q[a, b]
+
+    def cost(amp, strat):
+        targets = [dr.define_einst(Symbol('e'), amp)]
+        eval_seq = optimize(targets, contr_strat=strat)
+        assert verify_eval_seq(eval_seq, targets)
+        return get_flop_cost(eval_seq)
+
+    for strat in ContrStrat:
+        together = cost(core + extra, strat)
+        apart = cost(core, strat) + cost(extra, strat)
+        # The one extra operation is adding the two scalars together.
+        assert (together - apart).simplify() == 1, strat

--- a/tests/opt_order_test.py
+++ b/tests/opt_order_test.py
@@ -1,0 +1,188 @@
+"""Tests that the optimization result does not depend on incidental order.
+
+The constriction graph gets its vertices numbered in the order edges arrive,
+which follows the order the libparenth memoir is walked.  Issue #43 was the
+search reading those numbers, so that a different but equally valid walk gave
+a different answer.  These tests permute the walk and require the same result
+every time.  On the code before the fix, the ascending walk lost the effective
+T of the CCSD energy equation and both matrix factorizations below.
+"""
+
+import random
+
+import pytest
+from drudge import Drudge, PartHoleDrudge, Range
+from sympy import symbols, Symbol, IndexedBase, Rational
+
+import gristmill.optimize
+from gristmill import optimize, verify_eval_seq, get_flop_cost
+
+_REAL_SORTED = sorted
+
+
+def _looks_like_memoir(items):
+    """If the items are the entries of a libparenth memoir.
+
+    The memoir walk is the only sort in the optimizer that passes reverse=True
+    over pairs keyed by tuples of integers.
+    """
+    if not items:
+        return False
+    for entry in items:
+        if not (isinstance(entry, tuple) and len(entry) == 2):
+            return False
+        key = entry[0]
+        if not (
+                isinstance(key, tuple) and key
+                and all(isinstance(i, int) for i in key)
+        ):
+            return False
+    return True
+
+
+def _walk_memoir(monkeypatch, order):
+    """Make the optimizer walk the memoir in the given order.
+
+    ``order`` maps the sorted list of memoir entries to a permutation of it.
+    Every other call to ``sorted`` inside the optimizer is left alone.
+    """
+
+    def patched(iterable, **kwargs):
+        items = list(iterable)
+        if kwargs.get('reverse') and _looks_like_memoir(items):
+            return order(_REAL_SORTED(items))
+        return _REAL_SORTED(items, **kwargs)
+
+    monkeypatch.setattr(gristmill.optimize, 'sorted', patched, raising=False)
+
+
+def _shuffled(seed):
+    def order(items):
+        items = list(items)
+        random.Random(seed).shuffle(items)
+        return items
+
+    return order
+
+
+ORDERS = {
+    'descending': lambda items: list(reversed(items)),
+    'ascending': lambda items: list(items),
+    'by_size': lambda items: _REAL_SORTED(
+        items, key=lambda x: (len(x[0]), x[0])
+    ),
+    'shuffle_1': _shuffled(1),
+    'shuffle_2': _shuffled(2),
+    'shuffle_3': _shuffled(3),
+}
+
+
+@pytest.fixture(scope='module')
+def problems(spark_ctx):
+    """The problems whose answer used to depend on the walk order.
+
+    Each entry gives the targets, the substitutions for the optimizer, and the
+    number of definitions the right answer has.
+    """
+
+    res = {}
+
+    # The CCSD energy equation, where the effective T has to be found.  Not
+    # the CCSD energy equation exactly, the same as in the CC tests.
+    dr = PartHoleDrudge(spark_ctx)
+    p = dr.names
+    a, b = p.V_dumms[:2]
+    i, j = p.O_dumms[:2]
+    u = dr.two_body
+    t = IndexedBase('t')
+    energy = dr.define_einst(
+        Symbol('e'),
+        u[i, j, a, b] * t[a, b, i, j] * Rational(1, 2)
+        + u[i, j, a, b] * t[a, i] * t[b, j]
+    )
+    res['ccsd_energy'] = ([energy], {p.nv: p.no * 10}, 2)
+
+    # Two matrix problems.
+    dr = Drudge(spark_ctx)
+    m = symbols('m')
+    r = Range('M', 0, m)
+    dumms = symbols('a b c d e f g h')
+    dr.set_dumms(r, dumms)
+    dr.add_default_resolver(r)
+    a, b, c, e = dumms[0], dumms[1], dumms[2], dumms[4]
+    u, x, y, z = (IndexedBase(i) for i in ['U', 'X', 'Y', 'Z'])
+
+    target = dr.define_einst(
+        IndexedBase('T')[a, b],
+        u[a, b] * z[c, e] * x[e, c] + u[a, b] * z[c, e] * y[e, c]
+    )
+    res['disconnected_outer_product'] = ([target], {}, 3)
+
+    target = dr.define_einst(
+        Symbol('T'), x[b, a] * z[a, b] + y[a, b] * z[b, a]
+    )
+    res['needing_canonicalization'] = ([target], {}, 2)
+
+    return res
+
+
+@pytest.fixture(scope='module')
+def reference(problems):
+    """The result of the production walk, for comparison."""
+
+    res = {}
+    for name, (targets, substs, n_defs) in problems.items():
+        eval_seq = optimize(targets, substs=substs)
+        assert verify_eval_seq(eval_seq, targets)
+        assert len(eval_seq) == n_defs
+        res[name] = get_flop_cost(eval_seq)
+    return res
+
+
+@pytest.mark.parametrize('order', list(ORDERS))
+def test_memoir_walk_order_does_not_change_the_result(
+        monkeypatch, problems, reference, order
+):
+    """The result must be the same under any walk of the memoir."""
+
+    _walk_memoir(monkeypatch, ORDERS[order])
+
+    for name, (targets, substs, n_defs) in problems.items():
+        eval_seq = optimize(targets, substs=substs)
+        assert verify_eval_seq(eval_seq, targets)
+        assert len(eval_seq) == n_defs, name
+        assert get_flop_cost(eval_seq) == reference[name], name
+
+
+def test_rand_constr_gives_random_constrictions(spark_ctx):
+    """Random constriction has to be random.
+
+    An earlier version of the search sorted the candidates after shuffling
+    them, which silently turned ``rand_constr`` off.  Here a sum with many
+    equally good constrictions is optimized under a few seeds, and more than
+    one answer has to come out.  Every answer must still be correct.
+    """
+
+    dr = Drudge(spark_ctx)
+    n = symbols('n')
+    r = Range('r', 0, n)
+    dr.set_dumms(r, symbols('a b c d'))
+    dr.add_default_resolver(r)
+    a, b = symbols('a b')
+
+    xs = [IndexedBase('x%d' % i) for i in range(3)]
+    ys = [IndexedBase('y%d' % i) for i in range(3)]
+    amp = sum(
+        (i + 2 * j + 1) * xs[i][a, b] * ys[j][a, b]
+        for i in range(3) for j in range(3)
+    )
+    targets = [dr.define_einst(Symbol('r'), amp)]
+
+    seen = set()
+    for seed in range(8):
+        random.seed(seed)
+        eval_seq = optimize(targets, rand_constr=True)
+        assert verify_eval_seq(eval_seq, targets)
+        seen.add(tuple(str(i) for i in eval_seq))
+
+    assert len(seen) > 1


### PR DESCRIPTION
Closes #43.

## What was wrong

The summation optimization prunes its search for maximal profitable constrictable bicliques with a pivot rule, and orients the two parts of a biclique by comparing vertex numbers. Vertex numbers come from the order edges arrive, which follows the walk over the libparenth memoir. Two things went wrong.

**Profitable bicliques were being dropped.** The orientation was forced on the path the search took: the first vertex of part 1 had to exceed the first vertex of part 0. Bron-Kerbosch drops a vertex from CAND once its branch is done, which is sound only because that branch enumerated every biclique containing it. The orientation constraint can kill that branch, and then nothing else is allowed to reach the vertex:

```
ENTER d=2 parts=[0 | 1] n=(1, 1) saving=0.0
  cand = []                                            <- nothing to explore
  subg savings = {'(p0,v2)': '1.0 + 0.0·x + 20.0·x²'}  <- profitable
```

The search knows the augmentation is worth `1 + 20x²` and cannot reach it.

**Which ones got dropped depended on the numbering.** So the same problem gave different answers on Linux and macOS, and under different hash seeds. Over eighty generated problems under five orders, 60 of 71 came out the same either way. The spread was real: 240 against 440 on one problem, 2500 against 4500 on another.

## What this does

Three changes make the search independent of the numbering:

- the orientation is decided from the finished biclique rather than from the pair the search started with,
- ties between equally profitable bicliques are broken on content,
- candidates are walked in content order rather than vertex-number order.

And one restricts the pruning that was losing bicliques in the first place. The pivot rule rests on an exchange argument: a maximal biclique avoiding every neighbour of the pivot could have taken the pivot in, so it was not maximal. That holds only when the pivot has positive saving and every vertex the branch may still add is a same-part vertex the pivot can coexist with; then the pivot's saving is unchanged and the biclique is not maximal. The thesis's rule and the old code pivoted without those conditions. Pivoting is now used exactly where the conditions hold and never at the second-vertex level, and a branch and bound is added on top.

A biclique's saving is its gross saving less the excess costs of the edges it takes in. Excess cost is never negative, so ignoring the excess of edges not yet taken can only overestimate, which is what makes the bound valid. The gross saving follows from the marginal `_VertGross` already computes, and its increase is bilinear in the two part sizes, so it is largest at a corner of the reachable rectangle and four evaluations settle it. Branches that cannot beat the best found so far are dropped.

## Results

Order invariance, over eighty generated problems under five orders each, on a set held back until the end:

| | invariant | incorrect |
|---|---|---|
| master | 60 of 71 | 0 |
| this branch | **71 of 71** | 0 |

Timing. The earlier version of this branch traded correctness for a large regression, which the review caught. The first benchmark used a matrix target, so the two parts had different external indices, the orientation filter never applied, and the cost was invisible. On a scalar target it is very visible:

| nine by nine scalar sum | time | cost |
|---|---|---|
| master | 1.051 s | 16280 |
| orientation fix alone | 6.307 s | 1800 |
| with the bound | **0.641 s** | **1800** |

So the sound pruning is both faster than the unsound rule it replaces and faster than master, while the answer is nine times cheaper. Other shapes: `ccsd_doubles_complex` 0.223 s against 0.249 s, a 49-term matrix sum 0.613 s against 0.314 s.

Coupled-cluster working equations derived with drudge (energy plus the amplitude equations), optimized with `substs={nv: 5000, no: 1000}`. The cost from `get_flop_cost` is identical between master and this branch in every case, checked term by term on the full polynomial; the leading terms are:

| equations | master | this branch | unoptimized | optimized, master and this branch |
|---|---|---|---|---|
| CCD, TRAV, 21 terms | 0.14 s | 0.13 s | `21*no**4*nv**4` | `4*no**4*nv**2 + 6*no**3*nv**3 + 2*no**2*nv**4` |
| CCSD, TRAV, 80 terms | 0.81 s | 0.85 s | `66*no**4*nv**4` | `8*no**4*nv**2 + 8*no**3*nv**3 + 2*no**2*nv**4` |
| CCSD, EXHAUST | 1.03 s | 1.08 s | `66*no**4*nv**4` | `6*no**4*nv**2 + 8*no**3*nv**3 + 2*no**2*nv**4` |
| CCSDT, TRAV, 484 terms | 4.7 s | 4.6 s | `543*no**5*nv**5` | `10*no**5*nv**3 + 4*no**4*nv**4 + 2*no**3*nv**5` |

An earlier head of this branch, with pivoting removed outright, took 21.6 s on CCSDT: the bound alone did not prune those graphs. Commit `e4f6889` brings pivoting back where its argument holds, ranks vertices once per search instead of comparing sort keys at every node, and builds each biclique in one orientation again.

The bound was checked against the same search with it switched off, which is exhaustive. Over 140 generated problems the two agree on every cost, so it prunes harder while dropping nothing.

## Tests

Three regression tests, each failing on master with a more expensive answer:

```
assert 4*n**2 + 2*n + 1 == 4*n**2
assert 4*n**2 + 4*n     == 2*n**2 + 4*n
assert 5*n**2 + 3*n     == 4*n**2 + 4*n
```

Suite: 36 passed, previously 33, no existing test changed.

## Corrections to an earlier version of this description

An independent review found three claims here that did not hold, and they are worth stating rather than quietly deleting.

**The thesis does not require order invariance.** I had written that section 6.3.3 calls the vertex order arbitrary and so nothing may depend on it. It does not say that. The order exists to deduplicate the mirror pair, "arbitrary" means any anti-symmetric relation suffices for that, and the thesis then describes exactly what the code did: "In our implementation, < comparison based on an internal integral index given to each vertex is used, which is a total order." The defect stands on its own evidence, not on the thesis.

**Order dependence is narrowed, not removed.** What no longer decides the answer is the vertex numbering, an artefact of the order edges arrive. Substituting a different content-derived ordering, equally permitted, the reviewer measured invariance of 157 of 200 on their own problem set. Master under vertex renumbering was 142 of 200. The greedy search remains sensitive to which ordering it is given.

**The tie-break's necessity is set dependent.** On my problem set, removing it took a validation run from 71 of 71 to 67 of 71. On the reviewer's, removing it changed nothing at all. It is kept because it removes an arbitrary choice cheaply, not because a strong result demands it.

Also fixed from the review, in commit `5fcb2c3`: `rand_constr` was being disabled, because the shuffle fed into a sort; vertex content was keyed on `str` of the canonical form, which omits the range of a summation dummy and can collide; and the orientation test used `<`, which would drop a biclique whose two parts share their minimum vertex, reachable only once #45 is fixed. An earlier version of this description said these were fixed while the branch did not carry them; they are on the branch now.

Commit `3c5f397` corrects the comment at the memoir walk from #39. The ascending walk no longer loses the effective T: the suite passes under either direction, and the held-out and generated sets give one answer under eight permutations of the walk. The descending sort stays as a reproducibility measure only.

## What the ordering does not buy

Content order is still one particular order, and `Term.sort_key` ends in the amplitude, which carries the tensors' own names. So renaming the tensors reorders the vertices and can land the greedy search somewhere else. Eight consistent renamings of one isomorphic problem, `X[a,b] z[a] y[b] + 2 X[a,b] y[a] y[b] - X[a,b] u[a] y[b]`:

| naming | master | this branch |
|---|---|---|
| `X,y,z,u` | `4n² + 4n` | `2n² + 4n` |
| `A,W,V,T` | `2n² + 4n` | `2n² + 4n` |
| `mat,vy,vz,vu` | `4n² + 4n` | `2n² + 4n` |
| `M,p,q,r` | `6n² + 6n + 2` | `4n² + 4n` |
| `B,C,D,E` | `6n² + 6n + 2` | `4n² + 4n` |
| **distinct costs over 8 namings** | **3** | **2** |

This branch narrows the spread and lifts the worst case, and does not remove the effect. Stated precisely, the answer is a function of the mathematics *and of the names given to the tensors*, rather than of the order the graph happened to be built in. The names are at least the user's own choice and stay put between runs and platforms, which the numbering did not.

Three other ways of rewriting the same problem were checked and change nothing, on either version: the summation dummies (`reset_dumms` canonicalises them), the target's external symbols (canonicalised to the leading symbols of the pool), and the order terms and factors are written in the source (drudge canonicalises the input before the optimizer sees it).

No test is added for this. It records a limitation rather than a property, and pinning it would only fix in place a choice that has no argument behind it.

## What this still does not do

The outer loop is greedy. It applies the most profitable constriction and moves on, without looking at what that leaves behind. Two constrictions of equal saving can lead to different totals, which is why the tie-break exists and why it is arbitrary. Each individual step now searches its graph properly; the sequence of steps is still a heuristic.

## Why content order rather than the vertex numbering

#39 already made the numbering deterministic, by sorting the memoir walk. So determinism is not the argument here; locality is.

The search never asks for a vertex's rank on its own, only for comparisons: does this candidate come before that one, does this part hold the earlier vertex. Under content, the answer for any two vertices is settled by those two alone. Under the numbering it depended on everything inserted before both.

That is visible from the outside. Take three terms sharing a matrix, and add a fourth that shares no tensor with them and so cannot join any biclique with them:

```
core  = Σ_ab X[a,b] z[a] y[b] + 2 X[a,b] y[a] y[b] − X[a,b] u[a] y[b]
extra = Σ_ab P[a,b] Q[a,b]
```

Optimizing the two together should cost what optimizing them apart costs, plus the one addition that puts the two scalars together. On master it does not:

| | `cost(core+extra) − cost(core) − cost(extra)` |
|---|---|
| master, OPT / TRAV / EXHAUST | `1 − 2n²` |
| this branch, all four strategies | `1` |

Master gives `4n² + 4n` for the core alone and `2n² + 4n` for the same three terms when the unrelated one is present: a term that shares nothing, by luck, buying a better factorization. The only thing it changes about the core's graph is the numbering, which it shifts wholesale.

`tests/opt_order_test.py::test_unrelated_term_does_not_disturb_the_rest` pins this. It is one instance rather than a theorem, and its docstring says so: the outer loop is greedy and the bound carries an incumbent, so adding terms can legitimately change what is found. What it guards is the search reading anything that follows the order the graph happened to be built in.

## What the search can and cannot promise

Each greedy step now finds the most profitable biclique that a non-negative-saving path, walked in content order, can build. Two known ways remain for the true maximum of a graph to escape, and both are inherent in the thesis's search rule rather than introduced here:

- Theorem 6.1 does not imply the sentence the thesis draws from it. A profitable biclique can have every one-vertex-smaller sub-biclique at negative saving, so no non-negative path from a single edge reaches it. A 3-by-3 counterexample within the thesis's cost model exists (best saving 24, best reachable 14). Random tables never produced one; a hill climb did.
- Bron-Kerbosch makes each biclique the responsibility of the branch of its first vertex. With the non-negative-step rule, a biclique reachable along one path can be unreachable along the forced one. About 0.3 per cent of random dense instances.

Dropping the non-negative-step rule and letting the bound alone prune was tried. It gives the same answers at the same speed on every existing benchmark, and takes 29 seconds instead of 0.8 on a five-by-five star of expensive pairings under `EXHAUST`, and over ten minutes at six. Not adopted. The full review is written up separately.





