### PR TITLE
fix: Stop a sum with an index-free product crashing the interpreter

### DIFF
--- a/tests/opt_misc_test.py
+++ b/tests/opt_misc_test.py
@@ -57,6 +57,32 @@ def test_summation_shared_by_four_factors(simple_drudge):
     assert all(i == costs[0] for i in costs)
 
 
+def test_sum_with_an_index_free_product(simple_drudge):
+    """A sum in which one term reduces to an index-free product.
+
+    After the shared factor is pulled out, the second term leaves a scalar
+    behind, and the optimizer sends a product with no index at all to the
+    parenthesization extension.  That used to segfault the interpreter
+    (issue #45), through a null owning handle in cpypp.
+    """
+
+    dr = simple_drudge
+    a, b, c = dr.ds[:3]
+
+    q_mat, v = IndexedBase('Q'), IndexedBase('V')
+    q, s = IndexedBase('q'), IndexedBase('s')
+    targets = [dr.define_einst(
+        Symbol('res'),
+        q_mat[a, b] * q[a] * s[b]
+        + 2 * q_mat[a, b] * q_mat[a, b]
+        - q_mat[a, b] * v[a, c] * v[c, b]
+    )]
+
+    for strat in ContrStrat:
+        eval_seq = optimize(targets, contr_strat=strat)
+        assert verify_eval_seq(eval_seq, targets)
+
+
 def test_simple_scalar_optimization(spark_ctx):
     """Test optimization of a simple scalar.
 

--- a/tests/parenth_test.py
+++ b/tests/parenth_test.py
@@ -1,0 +1,44 @@
+"""Tests of the parenthesization extension at its own interface.
+
+The optimizer feeds every product node to ``parenth``.  Most of its behaviour
+is covered through the optimizer, but the degenerate shapes are easier to pin
+down here.
+"""
+
+import pytest
+
+from gristmill._parenth import parenth
+
+
+@pytest.mark.parametrize('mode', [0, 1, 2])
+@pytest.mark.parametrize('if_incl', [False, True])
+def test_factor_without_indices(mode, if_incl):
+    """A single factor with no index at all gives the trivial memoir.
+
+    No dimensions, no summations, one factor involving nothing.  This is what
+    the optimizer hands in for an index-free product, and it used to bring the
+    interpreter down: the empty dimension list gave an exhausted iterator whose
+    null value was copied while the ``dims`` vector was built (issue #45).
+    """
+
+    res = parenth([], 0, [[]], mode, if_incl)
+
+    assert list(res.keys()) == [(0,)]
+    interm = res[(0,)]
+    assert interm.sums == ()
+    assert interm.exts == ()
+    assert len(interm.evals) == 1
+    ev = interm.evals[0]
+    assert ev.ops == ((0,), ())
+    assert ev.sums == ()
+    assert ev.cost == 0
+
+
+def test_factor_with_a_single_index():
+    """The smallest non-degenerate problem, for comparison."""
+
+    res = parenth([5], 1, [[0]], 1, True)
+
+    assert list(res.keys()) == [(0,)]
+    assert res[(0,)].sums == (0,)
+    assert res[(0,)].exts == ()


### PR DESCRIPTION
Closes #45.

## Cause

Not in gristmill or libparenth: in cpypp. `Handle::incr_ref` called `Py_INCREF` on a null pointer when an owning null handle was copied. An `Iter_handle` over an empty Python list holds exactly such a value once exhausted, and

```cpp
std::vector<Handle> dims(dims_inp.begin(), dims_inp.end());
```

in `_parenth.cpp` copies it. A product with no index at all is what hands in the empty list. Found with the extension compiled into a driver under ASan and UBSan; the same crash reproduces at `de45ccf`, before #39, so it predates every recent change.

## Fix

Bump `deps/cpypp` to DrudgeCAS/cpypp#2, which uses `Py_XINCREF` and adds tests for the exhausted-iterator copy. The pin is the head of that PR's branch; if #2 is merged with a merge commit the pin stays reachable, otherwise it needs re-pointing to master after the merge.

## Tests

`tests/parenth_test.py`, new: `parenth([], 0, [[]], mode, if_incl)` for every mode and both flags returns the trivial memoir, plus the smallest non-degenerate case for comparison. `tests/opt_misc_test.py`: the sum from the issue optimizes and verifies under every contraction strategy. Both crashed the interpreter before the bump.

Suite: 34 passed with the printer tests deselected on this machine (they need gfortran and Julia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
