### PR TITLE
fix: Verify a result whatever its external symbols are called

### DIFF
--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -2965,7 +2965,30 @@ def verify_eval_seq(
         if base in res_dict:
             # For results.
             ref = res_dict[base]
-            diff = (new_def - ref.rhs).simplify()
+
+            # The optimization canonicalizes the external indices of a result,
+            # so they need not be the symbols the caller wrote.  The two
+            # definitions are then the same up to a renaming of those indices,
+            # which the subtraction below would read as a difference.
+            #
+            # Instantiate the new definition at the reference's indices first.
+            # This goes through the definition's own indexing rather than a
+            # bare substitution, so that the summations inside cannot be
+            # captured: the caller is free to use as an external index a
+            # symbol the optimization picked as a dummy.
+            new_exts = [i for i, _ in new_def.exts]
+            ref_exts = [i for i, _ in ref.exts]
+            if len(new_exts) != len(ref_exts):
+                raise ValueError(
+                    'Unequal number of external indices for ', base,
+                    new_exts, ref_exts
+                )
+
+            new_res = new_def if new_exts == ref_exts else new_def[
+                tuple(ref_exts)
+            ]
+
+            diff = (new_res - ref.rhs).simplify()
             if diff != 0:
                 raise ValueError('Unequal definition for ', base)
             del res_dict[base]

--- a/tests/opt_misc_test.py
+++ b/tests/opt_misc_test.py
@@ -2,7 +2,7 @@
 """
 
 import pytest
-from drudge import Drudge, Range
+from drudge import Drudge, Range, TensorDef
 from sympy import symbols, Symbol, IndexedBase, conjugate
 
 from gristmill import optimize, verify_eval_seq, get_flop_cost, ContrStrat
@@ -281,3 +281,75 @@ def test_get_cost_on_zero_cost(simple_drudge):
     ]:
         assert i == 0
         continue
+
+
+@pytest.mark.parametrize('ext_names,sum_name', [
+    ('a b', 'c'),
+    ('a b', 'e'),
+    ('b c', 'd'),
+    ('c d', 'e'),
+    ('f g', 'h'),
+    ('g h', 'a'),
+])
+def test_verification_of_a_result_with_any_external_symbols(
+        simple_drudge, ext_names, sum_name
+):
+    """Verification must not depend on which symbols the caller used.
+
+    The optimization canonicalizes the external indices of a result onto the
+    leading dummies of the range, so they need not be the symbols that were
+    written.  The verification used to subtract the two definitions as they
+    stood, read that renaming as a difference, and reject a correct answer
+    for every choice of external symbols but the canonical one.
+
+    The last case matters most: the caller's external symbols are the ones
+    the optimization picked as a summation dummy inside the result, so
+    lining the two up naively would capture that summation.
+    """
+
+    dr = simple_drudge
+    i0, i1 = symbols(ext_names)
+    k = symbols(sum_name)
+
+    x = IndexedBase('X')
+    y, z, u = (IndexedBase(i) for i in ['Y', 'Z', 'U'])
+    res = IndexedBase('res')
+
+    targets = [dr.define_einst(
+        res[i0, i1],
+        x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1]
+    )]
+
+    eval_seq = optimize(targets)
+    assert verify_eval_seq(eval_seq, targets)
+
+
+def test_verification_still_rejects_a_wrong_result(simple_drudge):
+    """The check has to keep failing on an answer that is actually wrong.
+
+    Guards the fix above from being a check that passes everything, in both
+    the canonical spelling of the external indices and another one.
+    """
+
+    dr = simple_drudge
+
+    x = IndexedBase('X')
+    y, z, u = (IndexedBase(i) for i in ['Y', 'Z', 'U'])
+    res = IndexedBase('res')
+
+    for ext_names, sum_name in [('a b', 'c'), ('c d', 'e')]:
+        i0, i1 = symbols(ext_names)
+        k = symbols(sum_name)
+        targets = [dr.define_einst(
+            res[i0, i1],
+            x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1]
+        )]
+
+        eval_seq = list(optimize(targets))
+        assert verify_eval_seq(eval_seq, targets)
+
+        # Scaling the result makes it wrong, whatever the indices are called.
+        final = eval_seq[-1]
+        eval_seq[-1] = TensorDef(final.base, final.exts, final.rhs * 2)
+        with pytest.raises(ValueError):
+            verify_eval_seq(eval_seq, targets)


### PR DESCRIPTION
Closes #49.

## What was wrong

`verify_eval_seq` compared the produced definition with the reference by subtracting one from the other as they stood:

```python
ref = res_dict[base]
diff = (new_def - ref.rhs).simplify()
```

The optimization canonicalizes the external indices of a result onto the leading dummies of the range, so they need not be the symbols the caller wrote. The two definitions are then the same up to a renaming of those indices, and the subtraction read that renaming as a difference.

So a correct answer was rejected for every choice of external symbols but the canonical one:

```
ext=a,b sum=c  -> verify=True
ext=a,b sum=e  -> verify=True
ext=b,c sum=d  -> ValueError: Unequal definition for res
ext=c,d sum=e  -> ValueError: Unequal definition for res
ext=f,g sum=h  -> ValueError: Unequal definition for res
ext=g,h sum=a  -> ValueError: Unequal definition for res
```

All six produce the same, correct sequence. It is the check that was wrong, and its message named the result while giving no hint that the indices were the reason. `verify_eval_seq` is the check the docstring advises for "mission-critical tasks", so a false alarm there sends the reader after an optimizer bug that does not exist.

## The change

Line the two up before subtracting, by instantiating the produced definition at the reference's indices.

This goes through `TensorDef.__getitem__` rather than a bare substitution, so the summations inside the result cannot be captured. That case is real rather than theoretical: for a target written over `c, d` the optimization produces

```
res[a, b] = u[a, b] + sum_{c} X[a, c]*tau^0[c, b]
```

whose internal summation is over `c`, one of the very symbols being substituted in. Instantiating at `c, d` gives

```
u[c, d] + sum_{a} X[c, a]*tau^0[a, d]
```

with the summation correctly renamed. A plain `xreplace` would have produced nonsense here.

Definitions whose externals already agree take the old path untouched, which is every result in the existing suite.

## Tests

`test_verification_of_a_result_with_any_external_symbols` runs the same equation under six choices of external and summation symbols, including `g, h` externals with `a` as the summation, which is the capture case.

`test_verification_still_rejects_a_wrong_result` guards against the obvious way to break this: a check that passes everything. It scales the result and requires the failure, in the canonical spelling and another one.

Without the fix, 5 of the 7 fail. With it, all pass; suite 42 passed with the printer tests deselected, which need gfortran and Julia.

## Scope

Independent of #44 and #47, and off master. The defect is old: it reproduces identically before and after every recent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
