### PR TITLE
ci: Lint and format with ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,31 @@
+name: Lint and Format
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
+
+      - name: Ruff lint
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,15 @@
+target-version = "py312"
+line-length = 79
+exclude = ["deps"]
+
+[lint]
+# State the rule set explicitly.  Leaving it implicit means inheriting
+# whatever ruff's defaults happen to be, and those change between releases:
+# ruff 0.16 widened them, which turns a green tree into 154 errors without
+# a line of this project's code changing.  These four are ruff's classic
+# defaults, and match the sibling drudge repository.
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E741"]
+
+[format]
+docstring-code-format = true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,37 +32,38 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.imgconverter'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.imgconverter",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'gristmill'
-copyright = '2017, Jinmo Zhao and Gustavo E Scuseria'
-author = 'Jinmo Zhao and Gustavo E Scuseria'
+project = "gristmill"
+copyright = "2017, Jinmo Zhao and Gustavo E Scuseria"
+author = "Jinmo Zhao and Gustavo E Scuseria"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-from gristmill import __version__
+from gristmill import __version__  # noqa: E402
+
 version = __version__
 # The full version, including alpha/beta/rc tags.
 release = version
@@ -77,10 +78,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -91,7 +92,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -102,13 +103,13 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'gristmilldoc'
+htmlhelp_basename = "gristmilldoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -117,15 +118,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -135,8 +133,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'gristmill.tex', 'gristmill Documentation',
-     'Jinmo Zhao and Gustavo E Scuseria', 'manual'),
+    (
+        master_doc,
+        "gristmill.tex",
+        "gristmill Documentation",
+        "Jinmo Zhao and Gustavo E Scuseria",
+        "manual",
+    ),
 ]
 
 
@@ -144,10 +147,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'gristmill', 'gristmill Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "gristmill", "gristmill Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -156,10 +156,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'gristmill', 'gristmill Documentation',
-     author, 'gristmill', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "gristmill",
+        "gristmill Documentation",
+        author,
+        "gristmill",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
-autodoc_member_order = 'bysource'
-
+autodoc_member_order = "bysource"

--- a/docs/examples/ccdmos.py
+++ b/docs/examples/ccdmos.py
@@ -27,7 +27,7 @@ NVNO_RATIO = 1
 
 def get_eval_seq():
     """Get the evaluation sequence for the benchmark."""
-    conf = SparkConf().setAppName('CCD-mosaic')
+    conf = SparkConf().setAppName("CCD-mosaic")
     ctx = SparkContext(conf=conf)
 
     dr = PartHoleDrudge(ctx)
@@ -37,17 +37,16 @@ def get_eval_seq():
     a, b, c, d = p.V_dumms[:4]
     i, j, k, l = p.O_dumms[:4]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
-    r = IndexedBase('r')
+    r = IndexedBase("r")
     tensor = dr.define_einst(
-        r[a, b, i, j],
-        t[a, b, l, j] * t[c, d, i, k] * u[k, l, c, d]
+        r[a, b, i, j], t[a, b, l, j] * t[c, d, i, k] * u[k, l, c, d]
     )
     targets = [tensor]
     eval_seq = optimize(
-        targets, substs={p.nv: p.no * NVNO_RATIO}, interm_fmt='tau{}'
+        targets, substs={p.nv: p.no * NVNO_RATIO}, interm_fmt="tau{}"
     )
 
     return eval_seq, types.SimpleNamespace(no=p.no, nv=p.nv)
@@ -69,25 +68,22 @@ def main():
     flop_cost_expr = get_flop_cost(eval_seq)
 
     for no in nos:
-        print('Benchmark NO={}'.format(no))
+        print("Benchmark NO={}".format(no))
         nv = no * NVNO_RATIO
         flop_cost = flop_cost_expr.xreplace({symbs.no: no, symbs.nv: nv})
 
         new_timings = tuple(
-            run_job(eval_seq, no, nv)
-            for run_job in [run_fortran, run_einsum]
+            run_job(eval_seq, no, nv) for run_job in [run_fortran, run_einsum]
         )
         timings.append(new_timings)
-        flops.append(tuple(
-            flop_cost / i for i in new_timings
-        ))
+        flops.append(tuple(flop_cost / i for i in new_timings))
         continue
 
-    with open('timing', 'w') as fp:
+    with open("timing", "w") as fp:
         for i, j in zip(nos, timings):
             print(i, *j, file=fp)
 
-    with open('flops', 'w') as fp:
+    with open("flops", "w") as fp:
         for i, j in zip(nos, flops):
             print(i, *j, file=fp)
             continue
@@ -102,17 +98,23 @@ def run_fortran(eval_seq, no, nv):
         no=no, nv=nv, decls=decls, evals=evals
     )
 
-    with open('ccdmos_run.f90', 'w') as fp:
+    with open("ccdmos_run.f90", "w") as fp:
         fp.write(fortran_code)
 
-    stat = subprocess.run([
-        'gfortran', '-fopenmp', '-o', 'f',
-        '-Wl,-stack_size', '-Wl,1000000000',
-        'ccdmos_run.f90'
-    ])
+    stat = subprocess.run(
+        [
+            "gfortran",
+            "-fopenmp",
+            "-o",
+            "f",
+            "-Wl,-stack_size",
+            "-Wl,1000000000",
+            "ccdmos_run.f90",
+        ]
+    )
     assert stat.returncode == 0
 
-    stat = subprocess.run(['./f'], stdout=subprocess.PIPE)
+    stat = subprocess.run(["./f"], stdout=subprocess.PIPE)
     timing = float(stat.stdout.decode())
 
     return timing
@@ -157,11 +159,11 @@ def run_einsum(eval_seq, no, nv):
     evals = printer.print_eval(eval_seq, base_indent=0)
 
     code = _EINSUM_TEMPLATE.render(no=no, nv=nv, evals=evals)
-    with open('ccdmos_run.py', 'w') as fp:
+    with open("ccdmos_run.py", "w") as fp:
         fp.write(code)
 
     stat = subprocess.run(
-        ['python3', './ccdmos_run.py'], stdout=subprocess.PIPE
+        ["python3", "./ccdmos_run.py"], stdout=subprocess.PIPE
     )
     timing = float(stat.stdout.decode())
 
@@ -188,5 +190,5 @@ print(time.time() - beg_time)
 
 """)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/gristmill/__init__.py
+++ b/gristmill/__init__.py
@@ -4,25 +4,30 @@ Public names are going to be imported here.
 """
 
 from .generate import (
-    BasePrinter, NaiveCodePrinter, CPrinter, FortranPrinter,
-    EinsumPrinter, OMEinsumPrinter, mangle_base
+    BasePrinter,
+    NaiveCodePrinter,
+    CPrinter,
+    FortranPrinter,
+    EinsumPrinter,
+    OMEinsumPrinter,
+    mangle_base,
 )
 from .optimize import optimize, verify_eval_seq, ContrStrat, RepeatedTermsStrat
 from .utils import get_flop_cost
 
-__version__ = '0.9.0'
+__version__ = "0.9.0"
 
 __all__ = [
-    'ContrStrat',
-    'RepeatedTermsStrat',
-    'optimize',
-    'verify_eval_seq',
-    'get_flop_cost',
-    'BasePrinter',
-    'mangle_base',
-    'NaiveCodePrinter',
-    'CPrinter',
-    'FortranPrinter',
-    'EinsumPrinter',
-    'OMEinsumPrinter'
+    "ContrStrat",
+    "RepeatedTermsStrat",
+    "optimize",
+    "verify_eval_seq",
+    "get_flop_cost",
+    "BasePrinter",
+    "mangle_base",
+    "NaiveCodePrinter",
+    "CPrinter",
+    "FortranPrinter",
+    "EinsumPrinter",
+    "OMEinsumPrinter",
 ]

--- a/gristmill/generate.py
+++ b/gristmill/generate.py
@@ -9,8 +9,16 @@ import typing
 
 from drudge.term import try_resolve_range
 from sympy import (
-    Expr, Add, Mul, Pow, Integer, Rational, Float, Indexed, IndexedBase,
-    Symbol
+    Expr,
+    Add,
+    Mul,
+    Pow,
+    Integer,
+    Rational,
+    Float,
+    Indexed,
+    IndexedBase,
+    Symbol,
 )
 from sympy.printing.printer import Printer
 from sympy.printing.c import C89CodePrinter
@@ -26,6 +34,7 @@ from .utils import JinjaEnv
 # General description of events
 # -----------------------------
 #
+
 
 class TensorComp:
     """Full description of a tensor computation.
@@ -43,8 +52,7 @@ class TensorComp:
 
     @property
     def is_interm(self):
-        """If the computation is an intermediate.
-        """
+        """If the computation is an intermediate."""
         return self._is_interm
 
     @property
@@ -54,14 +62,12 @@ class TensorComp:
 
     @property
     def ctx(self):
-        """The rendering context for the entire computation.
-        """
+        """The rendering context for the entire computation."""
         return self._ctx
 
     @property
     def target(self):
-        """The base of the target tensor to compute.
-        """
+        """The base of the target tensor to compute."""
         return self._def.base
 
     def __str__(self):
@@ -74,26 +80,23 @@ class TensorComp:
 
 
 class TensorDecl(typing.NamedTuple):
-    """Events for declaration of intermediate tensors.
-    """
+    """Events for declaration of intermediate tensors."""
 
     comput: TensorComp
 
     def __repr__(self):
-        """Form a string, mostly for debugging.
-        """
-        return '_TensorDecl({!s})'.format(self.comput)
+        """Form a string, mostly for debugging."""
+        return "_TensorDecl({!s})".format(self.comput)
 
 
 class BeginBody:
-    """Events for the beginning of the main computational body.
-    """
+    """Events for the beginning of the main computational body."""
+
     __slots__ = []
 
     def __repr__(self):
-        """Form a string representation.
-        """
-        return 'BeginBody()'
+        """Form a string representation."""
+        return "BeginBody()"
 
 
 class BeforeComp(typing.NamedTuple):
@@ -107,7 +110,7 @@ class BeforeComp(typing.NamedTuple):
 
     def __repr__(self):
         """Form a string, mostly for debugging."""
-        return '_BeforeCompute({!s})'.format(self.comput)
+        return "_BeforeCompute({!s})".format(self.comput)
 
 
 class CompTerm(typing.NamedTuple):
@@ -150,18 +153,17 @@ class OutOfUse(typing.NamedTuple):
 
     def __repr__(self):
         """Form a string, mostly for debugging."""
-        return '_NoLongerInUse({!s})'.format(self.comput)
+        return "_NoLongerInUse({!s})".format(self.comput)
 
 
 class EndBody:
-    """Events for the end of the main computational body.
-    """
+    """Events for the end of the main computational body."""
+
     __slots__ = []
 
     def __repr__(self):
-        """Form a string representation.
-        """
-        return 'EndBody()'
+        """Form a string representation."""
+        return "EndBody()"
 
 
 #
@@ -209,11 +211,14 @@ class BasePrinter(abc.ABC):
     """
 
     def __init__(
-            self, scal_printer: Printer, indexed_proc_cb=lambda x, p: None,
-            extr_unary=True, base_indent=1, **kwargs
+        self,
+        scal_printer: Printer,
+        indexed_proc_cb=lambda x, p: None,
+        extr_unary=True,
+        base_indent=1,
+        **kwargs,
     ):
-        """Initialize a base printer.
-        """
+        """Initialize a base printer."""
 
         env = JinjaEnv(**kwargs)
 
@@ -316,7 +321,6 @@ class BasePrinter(abc.ABC):
 
         # Render each term in turn.
         for term in tensor_def.rhs_terms:
-
             term_ctx = types.SimpleNamespace()
             term_ctx.orig_term = term
             terms.append(term_ctx)
@@ -353,26 +357,24 @@ class BasePrinter(abc.ABC):
                     numerator.append(factor)
                 continue
 
-            if (
-                len(denominator) == 0 and (
-                    len(numerator) == 1
-                    and isinstance(numerator[0], (Integer, Float, Symbol))
-                    or len(numerator) == 0
-                )
+            if len(denominator) == 0 and (
+                len(numerator) == 1
+                and isinstance(numerator[0], (Integer, Float, Symbol))
+                or len(numerator) == 0
             ):
                 term_ctx.single_factor = True
             else:
                 term_ctx.single_factor = False
 
-            term_ctx.phase = '+' if phase == 1 else '-'
+            term_ctx.phase = "+" if phase == 1 else "-"
             for i, j, k in [
-                (numerator, 'numerator', Add),
-                (denominator, 'denominator', (Add, Mul))
+                (numerator, "numerator", Add),
+                (denominator, "denominator", (Add, Mul)),
             ]:
                 val = prod_(i)
                 printed_val = self._print_scal(val)
                 if isinstance(val, k):
-                    printed_val = '(' + printed_val + ')'
+                    printed_val = "(" + printed_val + ")"
                 setattr(term_ctx, j, printed_val)
                 continue
 
@@ -388,10 +390,13 @@ class BasePrinter(abc.ABC):
                     factor_ctx = types.SimpleNamespace()
                     factor_ctx.base_expr = base
                     factor_ctx.base = self._print_scal(base)
-                    factor_ctx.indices = self._form_indices_ctx((
-                        (i, try_resolve_range(i, indices_dict, resolvers))
-                        for i in indices
-                    ), enforce=False)
+                    factor_ctx.indices = self._form_indices_ctx(
+                        (
+                            (i, try_resolve_range(i, indices_dict, resolvers))
+                            for i in indices
+                        ),
+                        enforce=False,
+                    )
                     indexed_factors.append(factor_ctx)
                 else:
                     other_factors_expr.append(factor)
@@ -408,9 +413,11 @@ class BasePrinter(abc.ABC):
         return ctx
 
     def proc_ctx(
-            self, tensor_def: TensorDef, term: typing.Optional[Term],
-            tensor_entry: types.SimpleNamespace,
-            term_entry: typing.Optional[types.SimpleNamespace]
+        self,
+        tensor_def: TensorDef,
+        term: typing.Optional[Term],
+        tensor_entry: types.SimpleNamespace,
+        term_entry: typing.Optional[types.SimpleNamespace],
     ):
         """Make additional processing of the rendering context.
 
@@ -435,21 +442,22 @@ class BasePrinter(abc.ABC):
         return
 
     def _form_indices_ctx(
-            self,
-            pairs: typing.Iterable[typing.Tuple[Expr, typing.Optional[Range]]],
-            enforce=True
+        self,
+        pairs: typing.Iterable[typing.Tuple[Expr, typing.Optional[Range]]],
+        enforce=True,
     ):
-        """Form indices context.
-        """
+        """Form indices context."""
 
         res = []
         for index, range_ in pairs:
-
             if range_ is None or not range_.bounded:
                 if enforce:
                     raise ValueError(
-                        'Invalid range to print', range_, 'for', index,
-                        'expecting a bounded range.'
+                        "Invalid range to print",
+                        range_,
+                        "for",
+                        index,
+                        "expecting a bounded range.",
                     )
                 else:
                     lower = None
@@ -466,12 +474,19 @@ class BasePrinter(abc.ABC):
                 upper = self._print_scal(upper_expr)
                 size = self._print_scal(size_expr)
 
-            res.append(types.SimpleNamespace(
-                index=self._print_scal(index), range=range_,
-                lower=lower, upper=upper, size=size,
-                index_expr=index, lower_expr=lower_expr, upper_expr=upper_expr,
-                size_expr=size_expr
-            ))
+            res.append(
+                types.SimpleNamespace(
+                    index=self._print_scal(index),
+                    range=range_,
+                    lower=lower,
+                    upper=upper,
+                    size=size,
+                    index_expr=index,
+                    lower_expr=lower_expr,
+                    upper_expr=upper_expr,
+                    size_expr=size_expr,
+                )
+            )
             continue
 
         return res
@@ -481,8 +496,7 @@ class BasePrinter(abc.ABC):
         return self._scal_printer.doprint(expr)
 
     def _extr_base_indices(self, factor):
-        """Attempt to extract base and indices from a factor.
-        """
+        """Attempt to extract base and indices from a factor."""
 
         # Direct extraction for indexed quantities.
         if isinstance(factor, Indexed):
@@ -581,7 +595,7 @@ class BasePrinter(abc.ABC):
         interms = set()  # Bases for the intermediates
         for idx, def_ in enumerate(defs):
             base = def_.base
-            is_interm = hasattr(def_, 'if_interm') and def_.if_interm
+            is_interm = hasattr(def_, "if_interm") and def_.if_interm
             comput = TensorComp(
                 is_interm=is_interm, def_=def_, ctx=self.transl(def_)
             )
@@ -609,9 +623,7 @@ class BasePrinter(abc.ABC):
                     if term.has_base(b):
                         b_idx = base2idx[b]
                         term_ctx.pend_prereqs.add(b_idx)
-                        computs[b_idx].deps[
-                            (comput_idx, term_idx)
-                        ] = None
+                        computs[b_idx].deps[(comput_idx, term_idx)] = None
                     continue
                 continue
             continue
@@ -650,8 +662,11 @@ class BasePrinter(abc.ABC):
         return events
 
     def _add_term_eval(
-            self, events, computs: typing.Sequence[TensorComp], comput_idx,
-            term_idx
+        self,
+        events,
+        computs: typing.Sequence[TensorComp],
+        comput_idx,
+        term_idx,
     ):
         """Add the evaluation of a term to the events list.
 
@@ -670,13 +685,15 @@ class BasePrinter(abc.ABC):
         term_ctx = term_ctxes[term_idx]
         if len(term_ctx.pend_prereqs) != 0:
             raise ValueError(
-                'Invalid evaluation sequence!', comput.target, 'needs',
-                [computs[i].target for i in term_ctx.pend_prereqs]
+                "Invalid evaluation sequence!",
+                comput.target,
+                "needs",
+                [computs[i].target for i in term_ctx.pend_prereqs],
             )
 
-        events.append(CompTerm(
-            comput=comput, term_idx=term_idx, term_ctx=term_ctx
-        ))
+        events.append(
+            CompTerm(comput=comput, term_idx=term_idx, term_ctx=term_ctx)
+        )
 
         # Possibly free dependent intermediates.
         for i in term_ctx.fin_prereqs:
@@ -772,7 +789,7 @@ class BasePrinter(abc.ABC):
             CompTerm: self.print_comp_term,
             OutOfUse: self.print_out_of_use,
             BeginBody: self.print_begin_body,
-            EndBody: self.print_end_body
+            EndBody: self.print_end_body,
         }
 
         for event in events:
@@ -782,18 +799,18 @@ class BasePrinter(abc.ABC):
             else:
                 cls = type(event)
                 if cls not in dispatch:
-                    raise ValueError('Invalid event', event)
+                    raise ValueError("Invalid event", event)
                 code = dispatch[cls](event)
                 self._add_section(execs, code)
             continue
 
         if separate_decls:
-            return '\n'.join(decls), '\n'.join(execs)
+            return "\n".join(decls), "\n".join(execs)
         else:
-            return '\n'.join(itertools.chain(decls, execs))
+            return "\n".join(itertools.chain(decls, execs))
 
     def _add_section(
-            self, secs: typing.List[str], new_sec: typing.Optional[str]
+        self, secs: typing.List[str], new_sec: typing.Optional[str]
     ):
         """Add a new section of code to the list of sections.
 
@@ -802,9 +819,7 @@ class BasePrinter(abc.ABC):
         set, with a new line guaranteed on the last line.
         """
         if new_sec is not None:
-            secs.append(self._env.indent_lines(
-                new_sec, self._base_indent
-            ))
+            secs.append(self._env.indent_lines(new_sec, self._base_indent))
 
     def render(self, templ_name: str, ctx: types.SimpleNamespace) -> str:
         """Render the given context for the given template.
@@ -895,12 +910,14 @@ def mangle_base(func):
 
         @mangle_base
         def print_indexed_base(base, indices):
-            o_slice = '0:m'
-            v_slice = 'm:n'
-            if base == 'f':
-                return 'f[{}]'.format(','.join(
-                    o_slice if i.range == o else v_slice for i in indices
-                ))
+            o_slice = "0:m"
+            v_slice = "m:n"
+            if base == "f":
+                return "f[{}]".format(
+                    ",".join(
+                        o_slice if i.range == o else v_slice for i in indices
+                    )
+                )
             else:
                 return base
 
@@ -954,8 +971,14 @@ class NaiveCodePrinter(BasePrinter):
     """
 
     def __init__(
-            self, scal_printer: Printer, print_indexed_cb, stmt_end='',
-            zero_literal='0.0', add_filters=None, add_globals=None, **kwargs
+        self,
+        scal_printer: Printer,
+        print_indexed_cb,
+        stmt_end="",
+        zero_literal="0.0",
+        add_filters=None,
+        add_globals=None,
+        **kwargs,
     ):
         """
         Initialize the automatic code printer.
@@ -981,16 +1004,16 @@ class NaiveCodePrinter(BasePrinter):
         """
 
         filters = {
-            'form_loop_opens': self._form_loop_opens,
-            'form_loop_closes': self._form_loop_closes
+            "form_loop_opens": self._form_loop_opens,
+            "form_loop_closes": self._form_loop_closes,
         }
         if add_filters is not None:
             filters.update(add_filters)
 
         # Some globals for template rendering.
         globals_ = {
-            'stmt_end': stmt_end,
-            'zero_literal': zero_literal,
+            "stmt_end": stmt_end,
+            "zero_literal": zero_literal,
         }
         if add_globals is not None:
             globals_.update(add_globals)
@@ -1003,9 +1026,11 @@ class NaiveCodePrinter(BasePrinter):
         self._print_indexed = print_indexed_cb
 
     def proc_ctx(
-            self, tensor_def: TensorDef, term: typing.Optional[Term],
-            tensor_entry: types.SimpleNamespace,
-            term_entry: typing.Optional[types.SimpleNamespace]
+        self,
+        tensor_def: TensorDef,
+        term: typing.Optional[Term],
+        tensor_entry: types.SimpleNamespace,
+        term_entry: typing.Optional[types.SimpleNamespace],
     ):
         """Process the context.
 
@@ -1025,7 +1050,7 @@ class NaiveCodePrinter(BasePrinter):
         else:
             factors = []
 
-            if term_entry.numerator != '1':
+            if term_entry.numerator != "1":
                 factors.append(term_entry.numerator)
 
             for i in term_entry.indexed_factors:
@@ -1038,11 +1063,11 @@ class NaiveCodePrinter(BasePrinter):
                     #
                     # cf BasePrinter._extr_base_indices.
                     symb = _get_only_symb(base_expr)
-                    placeholder_name = 'GRISTMILLINTERNALPLACEHOLDER'
+                    placeholder_name = "GRISTMILLINTERNALPLACEHOLDER"
                     placeholder = Symbol(placeholder_name)
-                    top = self._print_scal(base_expr.xreplace({
-                        symb: placeholder
-                    }))
+                    top = self._print_scal(
+                        base_expr.xreplace({symb: placeholder})
+                    )
                     indexed = self._print_indexed(str(symb), i.indices)
                     i.indexed = top.replace(placeholder_name, indexed)
 
@@ -1051,11 +1076,11 @@ class NaiveCodePrinter(BasePrinter):
 
             factors.extend(term_entry.other_factors)
 
-            parts = [' * '.join(factors)]
-            if term_entry.denominator != '1':
-                parts.extend(['/', term_entry.denominator])
+            parts = [" * ".join(factors)]
+            if term_entry.denominator != "1":
+                parts.extend(["/", term_entry.denominator])
 
-            term_entry.amp = ' '.join(parts)
+            term_entry.amp = " ".join(parts)
 
         return
 
@@ -1069,14 +1094,12 @@ class NaiveCodePrinter(BasePrinter):
 
     @abc.abstractmethod
     def form_loop_open(self, ctx) -> str:
-        """Form the loop opening for an index.
-        """
+        """Form the loop opening for an index."""
         pass
 
     @abc.abstractmethod
     def form_loop_close(self, ctx) -> str:
-        """Form the closing for a loop over the given index.
-        """
+        """Form the closing for a loop over the given index."""
         pass
 
     def _form_loop_opens(self, indices, base_level=0):
@@ -1085,7 +1108,7 @@ class NaiveCodePrinter(BasePrinter):
         This method is primarily for usage inside templates under the name
         without the initial underscore.
         """
-        return '\n'.join(
+        return "\n".join(
             self._env.form_indent(base_level + i) + self.form_loop_open(v)
             for i, v in enumerate(indices)
         )
@@ -1097,7 +1120,7 @@ class NaiveCodePrinter(BasePrinter):
         """
         n_indices = len(indices)
 
-        return '\n'.join(
+        return "\n".join(
             self._env.form_indent(base_level + n_indices - i - 1)
             + self.form_loop_close(v)
             for i, v in enumerate(reversed(indices))
@@ -1108,7 +1131,7 @@ class NaiveCodePrinter(BasePrinter):
 
         Here we only attempt to zero-out the tensor naively.
         """
-        return self.render('naivezero', event.comput.ctx)
+        return self.render("naivezero", event.comput.ctx)
 
     def print_comp_term(self, event: CompTerm):
         """Print the action to add a term to a target tensor.
@@ -1117,7 +1140,7 @@ class NaiveCodePrinter(BasePrinter):
         """
         ctx = event.comput.ctx
         ctx.term = event.term_ctx
-        code = self.render('naiveterm', ctx)
+        code = self.render("naiveterm", ctx)
         del ctx.term
         return code
 
@@ -1132,9 +1155,7 @@ def print_c_indexed(base, indices):
 
     The indexed will be printed as multi-dimensional array.
     """
-    return base + ''.join(
-        '[{}]'.format(i.index) for i in indices
-    )
+    return base + "".join("[{}]".format(i.index) for i in indices)
 
 
 class CPrinter(NaiveCodePrinter):
@@ -1152,21 +1173,25 @@ class CPrinter(NaiveCodePrinter):
         """
 
         super().__init__(
-            C89CodePrinter(), print_indexed_cb=print_indexed_cb,
-            line_cont='\\', stmt_end=';', **kwargs
+            C89CodePrinter(),
+            print_indexed_cb=print_indexed_cb,
+            line_cont="\\",
+            stmt_end=";",
+            **kwargs,
         )
 
     def form_loop_open(self, ctx):
-        """Form the loop opening for C.
-        """
-        return 'for({index}={lower}; {index}<{upper}; {index}++)'.format(
-            index=ctx.index, lower=ctx.lower, upper=ctx.upper
-        ) + ' {'
+        """Form the loop opening for C."""
+        return (
+            "for({index}={lower}; {index}<{upper}; {index}++)".format(
+                index=ctx.index, lower=ctx.lower, upper=ctx.upper
+            )
+            + " {"
+        )
 
     def form_loop_close(self, _):
-        """Form the loop closing for C.
-        """
-        return '}'
+        """Form the loop closing for C."""
+        return "}"
 
     #
     # Other abstract methods.
@@ -1179,23 +1204,22 @@ class CPrinter(NaiveCodePrinter):
         """
         ctx = event.comput.ctx
 
-        return '{} {}{};'.format('double', ctx.base, ''.join(
-            '[{}]'.format(i.size) for i in ctx.indices
-        ))
+        return "{} {}{};".format(
+            "double",
+            ctx.base,
+            "".join("[{}]".format(i.size) for i in ctx.indices),
+        )
 
     def print_begin_body(self, event: BeginBody):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
     def print_out_of_use(self, event: OutOfUse):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
     def print_end_body(self, event: EndBody):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
 
@@ -1210,9 +1234,9 @@ def print_fortran_indexed(base, indices):
     By default, the multi-dimensional array format will be used.
     """
     return base + (
-        '' if len(indices) == 0 else '({})'.format(', '.join(
-            i.index for i in indices
-        ))
+        ""
+        if len(indices) == 0
+        else "({})".format(", ".join(i.index for i in indices))
     )
 
 
@@ -1245,27 +1269,30 @@ class FortranPrinter(NaiveCodePrinter):
     """
 
     def __init__(
-            self, print_indexed_cb=print_fortran_indexed, openmp=True,
-            default_type='real', heap_interm=True, explicit_bounds=False,
-            **kwargs
+        self,
+        print_indexed_cb=print_fortran_indexed,
+        openmp=True,
+        default_type="real",
+        heap_interm=True,
+        explicit_bounds=False,
+        **kwargs,
     ):
-        """Initialize a naive Fortran code printer.
-
-
-        """
+        """Initialize a naive Fortran code printer."""
 
         if openmp:
             add_templ = {
-                'term_prelude': _FORTRAN_OMP_TERM_PRELUDE,
-                'term_finale': _FORTRAN_OMP_TERM_FINALE,
+                "term_prelude": _FORTRAN_OMP_TERM_PRELUDE,
+                "term_finale": _FORTRAN_OMP_TERM_FINALE,
             }
         else:
             add_templ = None
 
         super().__init__(
-            FCodePrinter(settings={'source_format': 'free'}),
-            print_indexed_cb=print_indexed_cb, line_cont='&',
-            add_templ=add_templ, **kwargs
+            FCodePrinter(settings={"source_format": "free"}),
+            print_indexed_cb=print_indexed_cb,
+            line_cont="&",
+            add_templ=add_templ,
+            **kwargs,
         )
 
         self._openmp = openmp
@@ -1278,17 +1305,16 @@ class FortranPrinter(NaiveCodePrinter):
     #
 
     def _form_bounds(self, ctx, explicit_bounds):
-        """Form the string for array bounds.
-        """
-        return ', '.join(
-            ':'.join([self._print_lower(i.lower_expr), i.upper])
-            if explicit_bounds else i.size
+        """Form the string for array bounds."""
+        return ", ".join(
+            ":".join([self._print_lower(i.lower_expr), i.upper])
+            if explicit_bounds
+            else i.size
             for i in ctx.indices
         )
 
     def _print_lower(self, lower: Expr):
-        """Print the lower bound based on the Fortran convention.
-        """
+        """Print the lower bound based on the Fortran convention."""
         return self._print_scal(lower + Integer(1))
 
     #
@@ -1296,19 +1322,17 @@ class FortranPrinter(NaiveCodePrinter):
     #
 
     def _form_loop_opens(self, indices, base_level=0):
-        """Form the nested loop openings for Fortran.
-        """
-        return '\n'.join(
+        """Form the nested loop openings for Fortran."""
+        return "\n".join(
             self._env.form_indent(base_level + i) + self.form_loop_open(v)
             for i, v in enumerate(reversed(indices))
         )
 
     def _form_loop_closes(self, indices, base_level=0):
-        """Form the nested loop closings for Fortran.
-        """
+        """Form the nested loop closings for Fortran."""
         n_indices = len(indices)
 
-        return '\n'.join(
+        return "\n".join(
             self._env.form_indent(base_level + n_indices - i - 1)
             + self.form_loop_close(v)
             for i, v in enumerate(indices)
@@ -1323,13 +1347,13 @@ class FortranPrinter(NaiveCodePrinter):
 
         lower = self._print_lower(ctx.lower_expr)
 
-        return 'do {index}={lower}, {upper}'.format(
+        return "do {index}={lower}, {upper}".format(
             index=ctx.index, lower=lower, upper=ctx.upper
         )
 
     def form_loop_close(self, _):
         """Form the loop ending for Fortran."""
-        return 'end do'
+        return "end do"
 
     #
     # For actual base printer.
@@ -1350,20 +1374,19 @@ class FortranPrinter(NaiveCodePrinter):
 
         if len(ctx.indices) > 0:
             if heap_interm:
-                bounds = ', '.join(':' for _ in ctx.indices)
+                bounds = ", ".join(":" for _ in ctx.indices)
             else:
                 bounds = self._form_bounds(ctx, explicit_bounds)
-            sizes_decl = ', dimension({})'.format(bounds)
+            sizes_decl = ", dimension({})".format(bounds)
             if heap_interm:
-                sizes_decl += ', allocatable'
+                sizes_decl += ", allocatable"
         else:
-            sizes_decl = ''
+            sizes_decl = ""
 
-        return '{}{} :: {}'.format(decl_type, sizes_decl, ctx.base)
+        return "{}{} :: {}".format(decl_type, sizes_decl, ctx.base)
 
     def print_begin_body(self, event: BeginBody):
-        """Start the OpenMP environment if enabled.
-        """
+        """Start the OpenMP environment if enabled."""
         if self._openmp:
             return _FORTRAN_OMP_START
         else:
@@ -1379,35 +1402,38 @@ class FortranPrinter(NaiveCodePrinter):
         explicit_bounds = self._explicit_bounds
 
         ctx = event.comput.ctx
-        zero_out = '{} = {}'.format(ctx.base, '0.0')
+        zero_out = "{} = {}".format(ctx.base, "0.0")
         if self._openmp:
-            zero_out = _FORTRAN_OMP_ZERO_PRELUDE + zero_out + '\n' \
-                    + _FORTRAN_OMP_ZERO_FINALE
+            zero_out = (
+                _FORTRAN_OMP_ZERO_PRELUDE
+                + zero_out
+                + "\n"
+                + _FORTRAN_OMP_ZERO_FINALE
+            )
 
         if_alloc = (
-                self._heap_interm and event.comput.is_interm
-                and len(event.comput.ctx.indices) > 0
+            self._heap_interm
+            and event.comput.is_interm
+            and len(event.comput.ctx.indices) > 0
         )
         if if_alloc:
             bounds = self._form_bounds(ctx, explicit_bounds)
-            alloc = 'allocate({}({}))\n'.format(ctx.base, bounds)
+            alloc = "allocate({}({}))\n".format(ctx.base, bounds)
             return alloc + zero_out
         else:
             return zero_out
 
     def print_out_of_use(self, event: OutOfUse):
-        """Print the deallocation command.
-        """
+        """Print the deallocation command."""
         assert event.comput.is_interm
         ctx = event.comput.ctx
         if not self._heap_interm or len(ctx.indices) == 0:
             return None
 
-        return 'deallocate({})'.format(ctx.base)
+        return "deallocate({})".format(ctx.base)
 
     def print_end_body(self, event: EndBody):
-        """Close OpenMP parallel body when enabled.
-        """
+        """Close OpenMP parallel body when enabled."""
         if self._openmp:
             return _FORTRAN_OMP_END
         else:
@@ -1476,21 +1502,25 @@ class EinsumPrinter(BasePrinter):
     """
 
     def __init__(
-            self, zeros='zeros', default_type='float64', einsum='einsum', extr_unary=True,
-            add_globals=None, **kwargs
+        self,
+        zeros="zeros",
+        default_type="float64",
+        einsum="einsum",
+        extr_unary=True,
+        add_globals=None,
+        **kwargs,
     ):
-        """Initialize the printer.
-        """
+        """Initialize the printer."""
 
-        globals_ = {
-            'einsum': einsum
-        }
+        globals_ = {"einsum": einsum}
         if add_globals is not None:
             globals_.update(add_globals)
 
         super().__init__(
-            PythonCodePrinter(), extr_unary=extr_unary, add_globals=globals_,
-            **kwargs
+            PythonCodePrinter(),
+            extr_unary=extr_unary,
+            add_globals=globals_,
+            **kwargs,
         )
 
         self._zeros = zeros
@@ -1498,58 +1528,50 @@ class EinsumPrinter(BasePrinter):
         self._einsum = einsum
 
     def print_decl(self, event: TensorDecl):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
     def print_begin_body(self, event: BeginBody):
-        """Import packages.
-        """
+        """Import packages."""
         preamble = "from numpy import zeros, dtype"
         return preamble
 
     def print_before_comp(self, event: BeforeComp):
-        """Initialize the tensor to zero.
-        """
+        """Initialize the tensor to zero."""
         ctx = event.comput.ctx
 
         if len(ctx.indices) > 0:
-            shape = '({})'.format(', '.join(
-                i.size for i in ctx.indices
-            ))
+            shape = "({})".format(", ".join(i.size for i in ctx.indices))
             if self._default_type is None:
                 args = shape
             else:
                 args = "{}, dtype='{}'".format(shape, self._default_type)
 
-            rhs = '{}({})'.format(self._zeros, args)
+            rhs = "{}({})".format(self._zeros, args)
         else:
             if self._default_type is None:
-                rhs = '0.0'
+                rhs = "0.0"
             else:
                 rhs = "dtype('{}').type(0)".format(self._default_type)
 
-        return '{} = {}'.format(ctx.base, rhs)
+        return "{} = {}".format(ctx.base, rhs)
 
     def print_comp_term(self, event: CompTerm):
-        """Print the evaluation of a term to be added to the target.
-        """
+        """Print the evaluation of a term to be added to the target."""
 
         ctx = event.comput.ctx
         ctx.term = event.term_ctx
-        code = self.render('einsum.jinja', ctx)
+        code = self.render("einsum.jinja", ctx)
         del ctx.term
 
         return code
 
     def print_out_of_use(self, event: OutOfUse):
-        """Remove an used intermediate tensor.
-        """
-        return 'del {}'.format(event.comput.ctx.base)
+        """Remove an used intermediate tensor."""
+        return "del {}".format(event.comput.ctx.base)
 
     def print_end_body(self, event: EndBody):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
 
@@ -1574,64 +1596,60 @@ class OMEinsumPrinter(BasePrinter):
     """
 
     def __init__(
-            self, default_type='Float64', extr_unary=True,
-            add_globals=None, **kwargs
+        self,
+        default_type="Float64",
+        extr_unary=True,
+        add_globals=None,
+        **kwargs,
     ):
-        """Initialize the printer.
-        """
+        """Initialize the printer."""
 
-        globals_ = {
-            'ein': 'ein'
-        }
+        globals_ = {"ein": "ein"}
         if add_globals is not None:
             globals_.update(add_globals)
 
         super().__init__(
-            JuliaCodePrinter(), extr_unary=extr_unary, add_globals=globals_,
-            **kwargs
+            JuliaCodePrinter(),
+            extr_unary=extr_unary,
+            add_globals=globals_,
+            **kwargs,
         )
 
-        self._zeros = 'zeros'
+        self._zeros = "zeros"
         self._default_type = default_type
-        self._ein_str = 'ein'
+        self._ein_str = "ein"
 
     def print_decl(self, event: TensorDecl):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
     def print_begin_body(self, event: BeginBody):
-        """Import packages.
-        """
-        preamble = "using LinearAlgebra, OMEinsum" 
+        """Import packages."""
+        preamble = "using LinearAlgebra, OMEinsum"
         return preamble
 
     def print_before_comp(self, event: BeforeComp):
-        """Initialize the tensor to zero.
-        """
+        """Initialize the tensor to zero."""
         ctx = event.comput.ctx
 
         if len(ctx.indices) > 0:
-            shape = '{}'.format(', '.join(
-                i.size for i in ctx.indices
-            ))
+            shape = "{}".format(", ".join(i.size for i in ctx.indices))
             if self._default_type is None:
                 args = shape
             else:
-                args = '{}, {}'.format(self._default_type, shape)
+                args = "{}, {}".format(self._default_type, shape)
 
-            rhs = '{}({})'.format(self._zeros, args)
+            rhs = "{}({})".format(self._zeros, args)
         else:
             if self._default_type is None:
-                rhs = '0.0'
+                rhs = "0.0"
             else:
-                rhs = 'zero({})'.format(self._default_type)
+                rhs = "zero({})".format(self._default_type)
 
-        return '{} = {}'.format(ctx.base, rhs)
+        return "{} = {}".format(ctx.base, rhs)
 
     def print_comp_term(self, event: CompTerm):
-        """Print the evaluation of a term to be added to the target.
-        """
+        """Print the evaluation of a term to be added to the target."""
 
         ctx = event.comput.ctx
         ctx.term = event.term_ctx
@@ -1639,21 +1657,19 @@ class OMEinsumPrinter(BasePrinter):
             len(ctx.term.indexed_factors) == 1
             and ctx.term.indexed_factors[0].indices == ctx.indices
         ):
-            code = self.render('omeinsum_nocopy.jinja', ctx)
+            code = self.render("omeinsum_nocopy.jinja", ctx)
         else:
-            code = self.render('ein_str.jinja', ctx)
+            code = self.render("ein_str.jinja", ctx)
         del ctx.term
 
         return code
 
     def print_out_of_use(self, event: OutOfUse):
-        """Remove an used intermediate tensor.
-        """
-        return '{} = nothing'.format(event.comput.ctx.base)
+        """Remove an used intermediate tensor."""
+        return "{} = nothing".format(event.comput.ctx.base)
 
     def print_end_body(self, event: EndBody):
-        """Do nothing.
-        """
+        """Do nothing."""
         return None
 
 
@@ -1661,6 +1677,7 @@ class OMEinsumPrinter(BasePrinter):
 # Tiny utilities
 # --------------
 #
+
 
 def _get_only_symb(expr: Expr):
     """Get the only symbol in the given expression.

--- a/gristmill/optimize.py
+++ b/gristmill/optimize.py
@@ -13,14 +13,20 @@ import warnings
 from drudge import TensorDef, prod_, Term, Range, sum_
 from networkx import Graph
 from sympy import (
-    Integer, Symbol, Expr, IndexedBase, Mul, Indexed, primitive, Wild,
-    default_sort_key, Pow
+    Integer,
+    Symbol,
+    Expr,
+    IndexedBase,
+    Mul,
+    Indexed,
+    primitive,
+    Wild,
+    default_sort_key,
+    Pow,
 )
 
 from ._parenth import parenth
-from .utils import (
-    Size, get_total_size, Tuple4Cmp, form_sized_range
-)
+from .utils import Size, get_total_size, Tuple4Cmp, form_sized_range
 
 
 #
@@ -113,11 +119,21 @@ class RepeatedTermsStrat(enum.Enum):
 
 
 def optimize(
-        computs: typing.Iterable[TensorDef], substs=None, simplify=True,
-        interm_fmt='tau^{}', contr_strat=ContrStrat.TRAV, opt_sum=True,
-        repeated_terms_strat=RepeatedTermsStrat.NATURAL, opt_symm=True,
-        req_an_opt=False, greedy_cutoff=-1, drop_cutoff=-1, rand_constr=False,
-        remove_shallow=True, res_at_end=True, stats=None
+    computs: typing.Iterable[TensorDef],
+    substs=None,
+    simplify=True,
+    interm_fmt="tau^{}",
+    contr_strat=ContrStrat.TRAV,
+    opt_sum=True,
+    repeated_terms_strat=RepeatedTermsStrat.NATURAL,
+    opt_symm=True,
+    req_an_opt=False,
+    greedy_cutoff=-1,
+    drop_cutoff=-1,
+    rand_constr=False,
+    remove_shallow=True,
+    res_at_end=True,
+    stats=None,
 ) -> typing.List[TensorDef]:
     """Optimize the evaluation of the given tensor computations.
 
@@ -230,27 +246,31 @@ def optimize(
 
     substs = {} if substs is None else substs
 
-    computs = [
-        i.simplify() if simplify else i.reset_dumms()
-        for i in computs
-    ]
+    computs = [i.simplify() if simplify else i.reset_dumms() for i in computs]
     if len(computs) == 0:
-        raise ValueError('No computation is given!')
+        raise ValueError("No computation is given!")
 
     if not isinstance(contr_strat, ContrStrat):
-        raise TypeError('Invalid contraction strategy', contr_strat)
+        raise TypeError("Invalid contraction strategy", contr_strat)
 
     if rand_constr:
         drop_cutoff = 2
         req_an_opt = True
 
     opt = _Optimizer(
-        computs, substs=substs, interm_fmt=interm_fmt,
-        contr_strat=contr_strat, opt_sum=opt_sum,
+        computs,
+        substs=substs,
+        interm_fmt=interm_fmt,
+        contr_strat=contr_strat,
+        opt_sum=opt_sum,
         repeated_terms_strat=repeated_terms_strat,
-        opt_symm=opt_symm, req_an_opt=req_an_opt,
-        greedy_cutoff=greedy_cutoff, drop_cutoff=drop_cutoff,
-        rand_constr=rand_constr, remove_shallow=remove_shallow, stats=stats
+        opt_symm=opt_symm,
+        req_an_opt=req_an_opt,
+        greedy_cutoff=greedy_cutoff,
+        drop_cutoff=drop_cutoff,
+        rand_constr=rand_constr,
+        remove_shallow=remove_shallow,
+        stats=stats,
     )
 
     return opt.optimize(res_at_end=res_at_end)
@@ -288,6 +308,7 @@ class _Grain(typing.NamedTuple):
 
     Basically it is a tensor definition with localized terms.
     """
+
     base: _Base
     exts: _SrPairs
     terms: _Terms
@@ -295,6 +316,7 @@ class _Grain(typing.NamedTuple):
 
 class _IntermRef(typing.NamedTuple):
     """A reference to an intermediate."""
+
     coeff: Expr
     base: _Base
     indices: _Indices
@@ -326,7 +348,7 @@ _SUMMED = 2
 _SUM_DIM = 0
 _EXT_DIM = 1
 
-_SUBSTED_EVAL_BASE = Symbol('gristmillSubstitutedEvalBase')
+_SUBSTED_EVAL_BASE = Symbol("gristmillSubstitutedEvalBase")
 
 
 #
@@ -339,7 +361,7 @@ class _SymbFactory(dict):
     """A small symbol factory."""
 
     def __missing__(self, key):
-        return Symbol('gristmillInternalSymbol{}'.format(key))
+        return Symbol("gristmillInternalSymbol{}".format(key))
 
 
 _SYMB_FACTORY = _SymbFactory()
@@ -349,7 +371,7 @@ class _WildFactory(dict):
     """A small wild symbol factory."""
 
     def __missing__(self, key):
-        return Wild('gristmillInternalWild{}'.format(key))
+        return Wild("gristmillInternalWild{}".format(key))
 
 
 _WILD_FACTORY = _WildFactory()
@@ -364,9 +386,7 @@ _WILD_FACTORY = _WildFactory()
 def _get_canon_coeff(coeffs, preferred):
     """Get the canonical coefficient from a list of coefficients."""
 
-    expr = sum(
-        v * _SYMB_FACTORY[i] for i, v in enumerate(coeffs)
-    ).together()
+    expr = sum(v * _SYMB_FACTORY[i] for i, v in enumerate(coeffs)).together()
 
     frac = _UNITY  # The fractional part.
     if isinstance(expr, Mul):
@@ -376,9 +396,9 @@ def _get_canon_coeff(coeffs, preferred):
             continue
         expr /= frac
 
-    coeff, _ = primitive(expr, *[
-        _SYMB_FACTORY[i] for i, _ in enumerate(coeffs)
-    ])
+    coeff, _ = primitive(
+        expr, *[_SYMB_FACTORY[i] for i, _ in enumerate(coeffs)]
+    )
 
     # Initial coefficient without phase.
     init_coeff = coeff * frac
@@ -404,7 +424,8 @@ def _get_canon_coeff(coeffs, preferred):
         phase = _UNITY
     else:
         preferred_phase = (
-            _NEG_UNITY if preferred.has(_NEG_UNITY) or preferred.is_negative
+            _NEG_UNITY
+            if preferred.has(_NEG_UNITY) or preferred.is_negative
             else _UNITY
         )
         phase = preferred_phase
@@ -434,12 +455,10 @@ def _index(base, indices, strip=False) -> Expr:
 
 
 class _EvalNode:
-    """A node in the evaluation graph.
-    """
+    """A node in the evaluation graph."""
 
     def __init__(self, base: Symbol, exts: _SrPairs):
-        """Initialize the evaluation node.
-        """
+        """Initialize the evaluation node."""
 
         self.base = base
         self.exts = exts
@@ -486,14 +505,13 @@ class _Sum(_EvalNode):
 
     def __repr__(self):
         """Form a representation string for the node."""
-        return '_Sum(base={}, exts={}, sum_terms={})'.format(
+        return "_Sum(base={}, exts={}, sum_terms={})".format(
             repr(self.base), repr(self.exts), repr(self.sum_terms)
         )
 
 
 class _Prod(_EvalNode):
-    """Product nodes in the evaluation graph.
-    """
+    """Product nodes in the evaluation graph."""
 
     def __init__(self, base, exts, sums, coeff, factors):
         """Initialize the node."""
@@ -504,9 +522,12 @@ class _Prod(_EvalNode):
 
     def __repr__(self):
         """Form a representation string for the node."""
-        return '_Prod(base={}, exts={}, sums={}, coeff={}, factors={})'.format(
-            repr(self.base), repr(self.exts), repr(self.sums),
-            repr(self.coeff), repr(self.factors)
+        return "_Prod(base={}, exts={}, sums={}, coeff={}, factors={})".format(
+            repr(self.base),
+            repr(self.exts),
+            repr(self.sums),
+            repr(self.coeff),
+            repr(self.factors),
         )
 
 
@@ -517,6 +538,7 @@ class _Interm(typing.NamedTuple):
     and the actual node for this, which can be helpful for getting
     information about a newly-formed intermediate.
     """
+
     ref: Expr
     node: _EvalNode
 
@@ -560,9 +582,9 @@ def _gen_broken_sums(sum_chunks):
             joined_size = curr_size * new_size
             joined_chunks = curr_chunks | 1 << next_idx
             joined_sums = curr_sums | new_sums
-            heapq.heappush(queue, Tuple4Cmp((
-                joined_size, joined_chunks, joined_sums
-            )))
+            heapq.heappush(
+                queue, Tuple4Cmp((joined_size, joined_chunks, joined_sums))
+            )
             if next_idx > 0:
                 top_idx = next_idx - 1
                 top_size, top_sums, _ = sum_chunks[top_idx]
@@ -570,10 +592,16 @@ def _gen_broken_sums(sum_chunks):
                 assert rem == 0
                 assert joined_chunks & 1 << top_idx
                 assert joined_sums & top_sums == top_sums
-                heapq.heappush(queue, Tuple4Cmp((
-                    new_size, joined_chunks ^ 1 << top_idx,
-                    joined_sums ^ top_sums
-                )))
+                heapq.heappush(
+                    queue,
+                    Tuple4Cmp(
+                        (
+                            new_size,
+                            joined_chunks ^ 1 << top_idx,
+                            joined_sums ^ top_sums,
+                        )
+                    ),
+                )
         continue
 
 
@@ -599,15 +627,12 @@ _OrgTerms = typing.DefaultDict[
 
 _LEFT = 0
 _RIGHT = 1
-_OPPOS = {
-    _LEFT: _RIGHT,
-    _RIGHT: _LEFT
-}
+_OPPOS = {_LEFT: _RIGHT, _RIGHT: _LEFT}
 
 # For type annotation, actually is should be ``_LEFT | _RIGHT`` in Haskell
 # algebraic data type notation.
 
-_LR = typing.NewType('_LR', int)
+_LR = typing.NewType("_LR", int)
 
 _LRS = (_LEFT, _RIGHT)
 
@@ -620,12 +645,14 @@ class _LastStepIdxes(typing.NamedTuple):
     accessing the actual graph.
 
     """
+
     exts: typing.Tuple[_SrPairs, _SrPairs]
     sums: _SrPairs
 
 
 class _EdgeInfo(typing.NamedTuple):
     """Information about an edge on a constriction graph."""
+
     term: int
     eval_: _Prod
     coeff: Expr
@@ -639,11 +666,7 @@ class _BaseInfo:
     optimizer class.
     """
 
-    __slots__ = [
-        'count',
-        'base',
-        'node'
-    ]
+    __slots__ = ["count", "base", "node"]
 
     def __init__(self, base: _Base, node: _Prod):
         """Initialize the information.
@@ -681,20 +704,16 @@ class _VertInfo(typing.NamedTuple):
 
 
 class _Delta(object):
-    """Additional information about augmentation by a designated vertex.
-    """
+    """Additional information about augmentation by a designated vertex."""
 
-    __slots__ = [
-        'coeff',
-        'leading_coeff',
-        'terms',
-        'exc_cost',
-        'saving'
-    ]
+    __slots__ = ["coeff", "leading_coeff", "terms", "exc_cost", "saving"]
 
     def __init__(
-            self, coeff: Expr, leading_coeff: typing.Optional[Expr],
-            terms: int, exc_cost: Size
+        self,
+        coeff: Expr,
+        leading_coeff: typing.Optional[Expr],
+        terms: int,
+        exc_cost: Size,
     ):
         """Initialize the delta."""
         self.coeff = coeff
@@ -706,6 +725,7 @@ class _Delta(object):
 
 class _DesVert(typing.NamedTuple):
     """Vertices designated for a specific part."""
+
     part: int
     vert: int
 
@@ -730,14 +750,15 @@ _ConstrParts = typing.Tuple[_VertsWCoeff, _VertsWCoeff]
 
 class _Biclique(typing.NamedTuple):
     """A biclique to be yielded."""
+
     parts: _ConstrParts
     leading_coeff: Expr
     terms: int
     saving: Size
-    constr_graph: '_ConstrGraph'
+    constr_graph: "_ConstrGraph"
 
 
-def _biclique_tie_key(biclique: '_Biclique'):
+def _biclique_tie_key(biclique: "_Biclique"):
     """Order two equally profitable bicliques.
 
     Equal saving happens often, and the greedy loop then has a real choice to
@@ -756,9 +777,9 @@ def _biclique_tie_key(biclique: '_Biclique'):
     vert_key = biclique.constr_graph.vert_key
 
     def side(part):
-        return tuple(sorted(
-            (vert_key(vert), str(coeff)) for vert, coeff in part
-        ))
+        return tuple(
+            sorted((vert_key(vert), str(coeff)) for vert, coeff in part)
+        )
 
     return (
         -biclique.terms.bit_count(),
@@ -794,19 +815,19 @@ def _get_cost_coeffs(last_step_idxes: _LastStepIdxes) -> _CostCoeffs:
 
     ext_size = get_total_size(itertools.chain.from_iterable(exts))
 
-    final = _get_prod_final_cost(
-        ext_size, get_total_size(sums)
-    ) + ext_size
+    final = _get_prod_final_cost(ext_size, get_total_size(sums)) + ext_size
 
     preps = (
         get_total_size(itertools.chain(exts[0], sums)),
-        get_total_size(itertools.chain(exts[1], sums))
+        get_total_size(itertools.chain(exts[1], sums)),
     )  # Explicitly repeated for linter.
 
     return _CostCoeffs(final=final, preps=preps)
 
 
-class _VertGross(typing.Dict[typing.Tuple[int, int], typing.Tuple[Size, Size]]):
+class _VertGross(
+    typing.Dict[typing.Tuple[int, int], typing.Tuple[Size, Size]]
+):
     """Gross saving of vertices.
 
     Given any numbers of vertices in the two parts, the gross saving of an
@@ -815,16 +836,14 @@ class _VertGross(typing.Dict[typing.Tuple[int, int], typing.Tuple[Size, Size]]):
 
     """
 
-    __slots__ = [
-        '_cost_coeffs'
-    ]
+    __slots__ = ["_cost_coeffs"]
 
     def __init__(self, last_step_idxes: _LastStepIdxes):
         """Initialize the dictionary."""
         self._cost_coeffs = _get_cost_coeffs(last_step_idxes)
 
     @property
-    def cost_coeffs(self) -> '_CostCoeffs':
+    def cost_coeffs(self) -> "_CostCoeffs":
         """The cost coefficients behind the gross savings."""
         return self._cost_coeffs
 
@@ -861,7 +880,7 @@ class _BronKerbosch:
     """
 
     def __init__(
-            self, last_step_idxes: _LastStepIdxes, constr_graph: '_ConstrGraph'
+        self, last_step_idxes: _LastStepIdxes, constr_graph: "_ConstrGraph"
     ):
         """Initialize the iterator."""
 
@@ -943,9 +962,10 @@ class _BronKerbosch:
         # run, which the numbering did not.
         vert_key = self._constr_graph.vert_key
         self._rank = {
-            vert: rank for rank, vert in enumerate(sorted(
-                {i.vert for i in subg}, key=lambda v: (vert_key(v), v)
-            ))
+            vert: rank
+            for rank, vert in enumerate(
+                sorted({i.vert for i in subg}, key=lambda v: (vert_key(v), v))
+            )
         }
 
         # For random constriction, if a biclique has ever been yielded.
@@ -997,7 +1017,8 @@ class _BronKerbosch:
             for j in (0, avail_r):
                 gain = (
                     final * (curr_l * j + curr_r * i + i * j)
-                    - preps[0] * i - preps[1] * j
+                    - preps[0] * i
+                    - preps[1] * j
                 )
                 if best is None or gain > best:
                     best = gain
@@ -1010,7 +1031,9 @@ class _BronKerbosch:
         return sorted(verts, key=lambda v: (v.part, rank[v.vert]))
 
     def _expand(
-            self, subg: _DesVertsWDelta, cand: _DesVerts,
+        self,
+        subg: _DesVertsWDelta,
+        cand: _DesVerts,
     ):
         """Generate the bicliques from the current state.
 
@@ -1040,9 +1063,11 @@ class _BronKerbosch:
 
         # Redundant check on biclique size is used to skip the possibly
         # expansive saving comparison.
-        if_profitable = all(
-            i > 0 for i in n_verts
-        ) and any(i > 1 for i in n_verts) and curr_saving >= 0
+        if_profitable = (
+            all(i > 0 for i in n_verts)
+            and any(i > 1 for i in n_verts)
+            and curr_saving >= 0
+        )
 
         # The two parts of a biclique are interchangeable, so each one would
         # otherwise be generated twice.  Keep only the orientation whose first
@@ -1065,9 +1090,8 @@ class _BronKerbosch:
             # `<=` admits both, and the two are then the same biclique so the
             # caller taking the best of them is unharmed.
             rank = self._rank
-            if_oriented = (
-                min(rank[i[0]] for i in curr[0])
-                <= min(rank[i[0]] for i in curr[1])
+            if_oriented = min(rank[i[0]] for i in curr[0]) <= min(
+                rank[i[0]] for i in curr[1]
             )
 
         if if_maximal and if_profitable and if_oriented:
@@ -1080,9 +1104,11 @@ class _BronKerbosch:
             if self._best_saving is None or curr_saving > self._best_saving:
                 self._best_saving = curr_saving
             yield _Biclique(
-                parts=curr, leading_coeff=self._leading_coeff,
-                terms=self._terms, saving=curr_saving,
-                constr_graph=self._constr_graph
+                parts=curr,
+                leading_coeff=self._leading_coeff,
+                terms=self._terms,
+                saving=curr_saving,
+                constr_graph=self._constr_graph,
             )
 
         if self._yielded and self._opt.rand_constr:
@@ -1260,8 +1286,7 @@ class _BronKerbosch:
             continue
 
     def _update_delta(
-            self, new_v: _DesVert, new_d: _Delta,
-            curr_v: _DesVert, curr_d: _Delta
+        self, new_v: _DesVert, new_d: _Delta, curr_v: _DesVert, curr_d: _Delta
     ) -> typing.Optional[_Delta]:
         """Update the delta assuming a new node is added to the stack.
 
@@ -1281,29 +1306,31 @@ class _BronKerbosch:
         curr_leading_coeff = curr_d.leading_coeff
 
         updated_d = _Delta(
-            coeff=curr_coeff, leading_coeff=curr_leading_coeff,
-            terms=curr_terms, exc_cost=curr_d.exc_cost
+            coeff=curr_coeff,
+            leading_coeff=curr_leading_coeff,
+            terms=curr_terms,
+            exc_cost=curr_d.exc_cost,
         )
 
         if new_p == curr_p:
             if new_leading_coeff is not None:
                 assert curr_leading_coeff is not None
                 updated_d.coeff = (
-                        curr_leading_coeff / new_leading_coeff
+                    curr_leading_coeff / new_leading_coeff
                 ).simplify()
                 updated_d.leading_coeff = None
         else:
-
             new_neighb = self._constr_graph.graph[new_v.vert]
             curr_vert = curr_v.vert
             if curr_vert not in new_neighb:
                 return None
-            edge = new_neighb[curr_vert]['info']
+            edge = new_neighb[curr_vert]["info"]
 
             edge_term = 1 << edge.term
             if_conflict = (
-                    edge_term & new_terms != 0 or edge_term & curr_terms != 0 or
-                    edge_term & self._terms != 0
+                edge_term & new_terms != 0
+                or edge_term & curr_terms != 0
+                or edge_term & self._terms != 0
             )
             if if_conflict:
                 return None
@@ -1315,9 +1342,7 @@ class _BronKerbosch:
 
             if new_leading_coeff is not None:
                 # The previous node gives the first edge.
-                updated_d.coeff = (
-                        edge_coeff / new_leading_coeff
-                ).simplify()
+                updated_d.coeff = (edge_coeff / new_leading_coeff).simplify()
             elif self._leading_coeff is None:
                 # This node gives the first edge.
                 updated_d.leading_coeff = edge_coeff
@@ -1346,7 +1371,7 @@ class _ConstrGraph:
     """
 
     def __init__(
-            self, constr_graphs: '_ConstrGraphs', exts_l: int, exts_r: int
+        self, constr_graphs: "_ConstrGraphs", exts_l: int, exts_r: int
     ):
         """Initialize the constriction graph.
 
@@ -1381,9 +1406,7 @@ class _ConstrGraph:
     @property
     def verts(self):
         """The nodes in the graph as integers with the information."""
-        return (
-            (i, j) for i, j in self.graph.nodes(data='info')
-        )
+        return ((i, j) for i, j in self.graph.nodes(data="info"))
 
     def vert_key(self, vert: int):
         """The sort key of the canonical content of a vertex.
@@ -1398,13 +1421,16 @@ class _ConstrGraph:
         keys = self._vert_keys
         if vert in keys:
             return keys[vert]
-        key = self.graph.nodes[vert]['info'].canon.sort_key
+        key = self.graph.nodes[vert]["info"].canon.sort_key
         keys[vert] = key
         return key
 
     def add_edge(
-            self, node_infos: typing.Tuple[_VertInfo, _VertInfo],
-            coeff: Expr, term: int, eval_: _Prod
+        self,
+        node_infos: typing.Tuple[_VertInfo, _VertInfo],
+        coeff: Expr,
+        term: int,
+        eval_: _Prod,
     ):
         """Add a new edge to the graph."""
 
@@ -1448,17 +1474,16 @@ class _ConstrGraph:
             # It is possible that two evaluations actually the same be
             # recorded twice in the evaluation of product nodes because of
             # symmetry.
-            assert neighb1[n2]['info'].term == edge_info.term
+            assert neighb1[n2]["info"].term == edge_info.term
         else:
             graph.add_edge(*nodes, info=edge_info)
 
         self.terms |= 1 << term
 
     def get_opt_biclique(
-            self, last_step_idxes: _LastStepIdxes
+        self, last_step_idxes: _LastStepIdxes
     ) -> typing.Tuple[typing.Optional[Size], typing.Optional[_Biclique]]:
-        """Get the optimal biclique in the current graph.
-        """
+        """Get the optimal biclique in the current graph."""
 
         if self._opt_saving is not None:
             if self._opt_saving is False:
@@ -1471,7 +1496,6 @@ class _ConstrGraph:
         opt_key = None
 
         for biclique in _BronKerbosch(last_step_idxes, self):
-
             saving = biclique.saving
 
             # The key is only needed on a tie, and it is not cheap, so it is
@@ -1491,8 +1515,8 @@ class _ConstrGraph:
 
             if better:
                 opt_saving = saving
-                opt_key = key if key is not None else _biclique_tie_key(
-                    biclique
+                opt_key = (
+                    key if key is not None else _biclique_tie_key(biclique)
                 )
                 # Make copy only when we need them.
                 parts = biclique.parts
@@ -1500,8 +1524,9 @@ class _ConstrGraph:
                 opt_biclique = _Biclique(
                     parts=(list(parts[0]), list(parts[1])),
                     leading_coeff=biclique.leading_coeff,
-                    terms=biclique.terms, saving=biclique.saving,
-                    constr_graph=biclique.constr_graph
+                    terms=biclique.terms,
+                    saving=biclique.saving,
+                    constr_graph=biclique.constr_graph,
                 )
 
             continue
@@ -1527,13 +1552,12 @@ class _ConstrGraph:
 
         if self.terms & terms != 0:
             edges2remove = [
-                (n1, n2) for n1, n2, info in graph.edges(data='info')
+                (n1, n2)
+                for n1, n2, info in graph.edges(data="info")
                 if 1 << info.term & terms != 0
             ]
             graph.remove_edges_from(edges2remove)
-            nodes2remove = [
-                i for i in graph.nodes() if graph.degree(i) == 0
-            ]
+            nodes2remove = [i for i in graph.nodes() if graph.degree(i) == 0]
             graph.remove_nodes_from(nodes2remove)
 
             self.terms ^= self.terms & terms
@@ -1568,13 +1592,9 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
 
     """
 
-    __slots__ = [
-        'opt',
-        'bases',
-        'term_bases'
-    ]
+    __slots__ = ["opt", "bases", "term_bases"]
 
-    def __init__(self, opt: '_Optimizer'):
+    def __init__(self, opt: "_Optimizer"):
         """Initialize the graphs.
 
         Here only the most basic resource initialization is performed.
@@ -1588,18 +1608,18 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
         # None for plain scalar terms.
         self.term_bases: typing.List[typing.Optional[_BaseInfo]] = []
 
-    def get_opt_biclique(self) -> typing.Tuple[
+    def get_opt_biclique(
+        self,
+    ) -> typing.Tuple[
         typing.Optional[_LastStepIdxes], typing.Optional[_Biclique]
     ]:
-        """Choose the most profitable biclique.
-        """
+        """Choose the most profitable biclique."""
 
         opt_saving = None
         opt_last_step_idxes = None
         opt_biclique = None
         opt_key = None
         for last_step_idxes, constr_graph in self.items():
-
             curr_opt_saving, curr_opt_biclique = constr_graph.get_opt_biclique(
                 last_step_idxes
             )
@@ -1622,8 +1642,10 @@ class _ConstrGraphs(typing.Dict[_LastStepIdxes, _ConstrGraph]):
 
             if better:
                 opt_saving = curr_opt_saving
-                opt_key = key if key is not None else _biclique_tie_key(
-                    curr_opt_biclique
+                opt_key = (
+                    key
+                    if key is not None
+                    else _biclique_tie_key(curr_opt_biclique)
                 )
                 opt_last_step_idxes = last_step_idxes
                 opt_biclique = curr_opt_biclique
@@ -1669,9 +1691,20 @@ class _Optimizer:
     #
 
     def __init__(
-            self, computs, substs, interm_fmt,
-            contr_strat, opt_sum, repeated_terms_strat, opt_symm, req_an_opt,
-            greedy_cutoff, drop_cutoff, rand_constr, remove_shallow, stats
+        self,
+        computs,
+        substs,
+        interm_fmt,
+        contr_strat,
+        opt_sum,
+        repeated_terms_strat,
+        opt_symm,
+        req_an_opt,
+        greedy_cutoff,
+        drop_cutoff,
+        rand_constr,
+        remove_shallow,
+        stats,
     ):
         """Initialize the optimizer."""
 
@@ -1687,9 +1720,7 @@ class _Optimizer:
         self._excl = set()
 
         # Read, process, and verify user input.
-        self._grist = [
-            self._form_grain(comput, substs) for comput in computs
-        ]
+        self._grist = [self._form_grain(comput, substs) for comput in computs]
 
         # Dummies stock in terms of the substituted range.
         assert self._drudge is not None
@@ -1725,8 +1756,7 @@ class _Optimizer:
         self._res = None
 
     def optimize(self, res_at_end=True):
-        """Optimize the evaluation of the given computations.
-        """
+        """Optimize the evaluation of the given computations."""
 
         if self._res is not None:
             return self._res
@@ -1739,7 +1769,7 @@ class _Optimizer:
         self._res = self._linearize(res_nodes, res_at_end=res_at_end)
 
         if self.stats is not None:
-            self.stats['Number of nodes'] = len(self._interms_canon)
+            self.stats["Number of nodes"] = len(self._interms_canon)
 
         return self._res
 
@@ -1748,16 +1778,15 @@ class _Optimizer:
     #
 
     def _form_grain(self, comput, substs):
-        """Form grain for a given computation.
-        """
+        """Form grain for a given computation."""
 
         curr_drudge = comput.rhs.drudge
         if self._drudge is None:
             self._drudge = curr_drudge
         elif self._drudge is not curr_drudge:
             raise ValueError(
-                'Invalid computations to optimize, containing two drudges',
-                (self._drudge, curr_drudge)
+                "Invalid computations to optimize, containing two drudges",
+                (self._drudge, curr_drudge),
             )
         else:
             pass
@@ -1771,7 +1800,7 @@ class _Optimizer:
         for term in comput.rhs_terms:
             if not term.is_scalar:
                 raise ValueError(
-                    'Invalid term to optimize', term, 'expecting scalar'
+                    "Invalid term to optimize", term, "expecting scalar"
                 )
             sums = self._proc_sums(term.sums, substs, sort=True)
             amp = term.amp
@@ -1784,7 +1813,8 @@ class _Optimizer:
 
         return _Grain(
             base=comput.base if len(exts) == 0 else comput.base.args[0],
-            exts=exts, terms=terms
+            exts=exts,
+            terms=terms,
         )
 
     def _proc_sums(self, sums, substs, sort=False):
@@ -1796,7 +1826,6 @@ class _Optimizer:
 
         res = []
         for symb, range_ in sums:
-
             new_range, range_var = form_sized_range(range_, substs)
 
             if range_var is not None:
@@ -1804,8 +1833,12 @@ class _Optimizer:
                     self._range_var = range_var
                 elif self._range_var != range_var:
                     raise ValueError(
-                        'Invalid range', range_, 'unexpected symbol',
-                        range_var, 'conflicting with', self._range_var
+                        "Invalid range",
+                        range_,
+                        "unexpected symbol",
+                        range_var,
+                        "conflicting with",
+                        self._range_var,
                     )
                 else:
                     pass
@@ -1814,8 +1847,9 @@ class _Optimizer:
                 self._input_ranges[new_range] = range_
             elif range_.size != self._input_ranges[new_range].size:
                 raise ValueError(
-                    'Invalid ranges', (range_, self._input_ranges[new_range]),
-                    'duplicated labels'
+                    "Invalid ranges",
+                    (range_, self._input_ranges[new_range]),
+                    "duplicated labels",
                 )
             else:
                 pass
@@ -1833,10 +1867,9 @@ class _Optimizer:
     #
 
     def _linearize(
-            self, optimized: typing.Sequence[_EvalNode], res_at_end=True
+        self, optimized: typing.Sequence[_EvalNode], res_at_end=True
     ) -> typing.List[TensorDef]:
-        """Linearize optimized forms of the evaluation.
-        """
+        """Linearize optimized forms of the evaluation."""
 
         for node in optimized:
             self._set_n_refs(node)
@@ -1858,17 +1891,16 @@ class _Optimizer:
         return self._finalize(itertools.chain(interms, res))
 
     def _set_n_refs(self, node: _EvalNode):
-        """Set reference counts from an evaluation node.
-        """
+        """Set reference counts from an evaluation node."""
 
         if len(node.evals) == 0:
             self._optimize(node)
 
         # We need to find an evaluation with optimal cost.
         assert len(node.evals) > 0
-        node.evals = [next(
-            i for i in node.evals if i.total_cost == node.total_cost
-        )]
+        node.evals = [
+            next(i for i in node.evals if i.total_cost == node.total_cost)
+        ]
         eval_ = node.evals[0]
 
         if isinstance(eval_, _Prod):
@@ -1933,19 +1965,15 @@ class _Optimizer:
         eval_ = node.evals[0]
         assert isinstance(eval_, _Prod)
         term, deps = self._form_prod_def_term(eval_)
-        return _Grain(
-            base=node.base, exts=exts, terms=[term]
-        ), deps
+        return _Grain(base=node.base, exts=exts, terms=[term]), deps
 
     def _form_prod_def_term(self, eval_: _Prod):
-        """Form the term in the final definition of a product evaluation node.
-        """
+        """Form the term in the final definition of a product evaluation node."""
 
         amp = eval_.coeff
 
         deps = []
         for factor in eval_.factors:
-
             ref = self._parse_interm_ref(factor)
             if ref is not None:
                 assert ref.coeff == 1
@@ -1977,7 +2005,6 @@ class _Optimizer:
         sum_terms = []
         self._inline_sum_terms(eval_.sum_terms, sum_terms)
         for term in sum_terms:
-
             ref = self._parse_interm_ref(term)
             if ref is None:
                 terms.append(Term((), term, ()))
@@ -2006,8 +2033,11 @@ class _Optimizer:
                 # Switch back to evaluation node for using the facilities for
                 # product nodes.
                 tmp_node = _Prod(
-                    term_node.base, exts, term.sums,
-                    ref.coeff * term_coeff, factors
+                    term_node.base,
+                    exts,
+                    term.sums,
+                    ref.coeff * term_coeff,
+                    factors,
                 )
                 new_term, term_deps = self._form_prod_def_term(tmp_node)
 
@@ -2015,18 +2045,14 @@ class _Optimizer:
                 deps.extend(term_deps)
 
             else:
-                terms.append(Term(
-                    (), term, ()
-                ))
+                terms.append(Term((), term, ()))
                 deps.append(ref.base)
             continue
 
-        return _Grain(
-            base=node.base, exts=exts, terms=terms
-        ), deps
+        return _Grain(base=node.base, exts=exts, terms=terms), deps
 
     def _inline_sum_terms(
-            self, sum_terms: typing.Sequence[Expr], res: typing.List[Expr]
+        self, sum_terms: typing.Sequence[Expr], res: typing.List[Expr]
     ):
         """Inline the summation terms from single-reference terms.
 
@@ -2046,20 +2072,18 @@ class _Optimizer:
             eval_ = node.evals[0]
 
             if_inline = isinstance(eval_, _Sum) and (
-                    node.n_refs == 1 or len(eval_.sum_terms) == 1
+                node.n_refs == 1 or len(eval_.sum_terms) == 1
             )
             if if_inline:
                 if len(node.exts) == 0:
                     substs = None
                 else:
-                    substs = {
-                        i[0]: j for i, j in zip(eval_.exts, ref.indices)
-                    }
+                    substs = {i[0]: j for i, j in zip(eval_.exts, ref.indices)}
 
                 proced_sum_terms = [
-                    (
-                        i.xreplace(substs) if substs is not None else sum_term
-                    ) * ref.coeff for i in eval_.sum_terms
+                    (i.xreplace(substs) if substs is not None else sum_term)
+                    * ref.coeff
+                    for i in eval_.sum_terms
                 ]
                 self._inline_sum_terms(proced_sum_terms, res)
                 continue
@@ -2072,14 +2096,16 @@ class _Optimizer:
     def _is_input(self, node: _EvalNode):
         """Test if a product node is just a trivial reference to an input."""
         if isinstance(node, _Prod):
-            return len(node.sums) == 0 and len(node.factors) == 1 and (
-                    self._parse_interm_ref(node.factors[0]) is None
+            return (
+                len(node.sums) == 0
+                and len(node.factors) == 1
+                and (self._parse_interm_ref(node.factors[0]) is None)
             )
         else:
             return False
 
     def _finalize(
-            self, computs: typing.Iterable[_Grain]
+        self, computs: typing.Iterable[_Grain]
     ) -> typing.List[TensorDef]:
         """Finalize the linearization result.
 
@@ -2109,9 +2135,11 @@ class _Optimizer:
             base = comput.base if if_scalar else IndexedBase(comput.base)
 
             terms = [
-                i.map(proc_amp, sums=tuple(
-                    (s, self._input_ranges[r]) for s, r in i.sums
-                )) for i in comput.terms
+                i.map(
+                    proc_amp,
+                    sums=tuple((s, self._input_ranges[r]) for s, r in i.sums),
+                )
+                for i in comput.terms
             ]
 
             # No internal intermediates should be leaked.
@@ -2119,28 +2147,37 @@ class _Optimizer:
                 assert not any(j in self._interms for j in i.free_vars)
 
             if comput.base in self._interms:
-
                 if_shallow = (
-                        remove_shallow and len(terms) == 1
-                        and len(terms[0].sums) == 0
+                    remove_shallow
+                    and len(terms) == 1
+                    and len(terms[0].sums) == 0
                 )
                 if if_shallow:
                     # Remove shallow intermediates.  The saving might be too
                     # modest to justify the additional memory consumption.
                     #
                     # TODO: Move it earlier to a better place.
-                    repl_lhs = base if if_scalar else base[tuple(
-                        _WILD_FACTORY[i] for i, _ in enumerate(exts)
-                    )]
-                    repl_rhs = proc_amp(terms[0].amp.xreplace(
-                        {v[0]: _WILD_FACTORY[i] for i, v in enumerate(exts)}
-                    ))
+                    repl_lhs = (
+                        base
+                        if if_scalar
+                        else base[
+                            tuple(_WILD_FACTORY[i] for i, _ in enumerate(exts))
+                        ]
+                    )
+                    repl_rhs = proc_amp(
+                        terms[0].amp.xreplace(
+                            {
+                                v[0]: _WILD_FACTORY[i]
+                                for i, v in enumerate(exts)
+                            }
+                        )
+                    )
                     repls.append((repl_lhs, repl_rhs))
                     continue  # No new intermediate added.
 
-                final_base = (
-                    Symbol if if_scalar else IndexedBase
-                )(self.interm_fmt.format(next_idx))
+                final_base = (Symbol if if_scalar else IndexedBase)(
+                    self.interm_fmt.format(next_idx)
+                )
                 next_idx += 1
                 substs[base] = final_base
                 if_interm = True
@@ -2162,11 +2199,10 @@ class _Optimizer:
     #
 
     def _get_next_internal(self):
-        """Get the symbol for the next internal intermediate.
-        """
+        """Get the symbol for the next internal intermediate."""
         idx = self._next_internal_idx
         self._next_internal_idx += 1
-        return Symbol('gristmillInternalIntermediate{}'.format(idx))
+        return Symbol("gristmillInternalIntermediate{}".format(idx))
 
     @staticmethod
     def _write_in_orig_ranges(sums):
@@ -2174,9 +2210,7 @@ class _Optimizer:
 
         The labels in the ranges are assumed to be decorated.
         """
-        return tuple(
-            (i, j.replace_label(j.label[0])) for i, j in sums
-        )
+        return tuple((i, j.replace_label(j.label[0])) for i, j in sums)
 
     def _canon_terms(self, new_sums: _SrPairs, terms: typing.Iterable[Term]):
         """Form a canonical label for a list of terms.
@@ -2211,9 +2245,9 @@ class _Optimizer:
             factors, coeff = term.get_amp_factors(self._interms)
             coeffs.append(coeff)
 
-            candidates[
-                term.map(lambda x: prod_(factors))
-            ].append((canon_sums, idx))
+            candidates[term.map(lambda x: prod_(factors))].append(
+                (canon_sums, idx)
+            )
             continue
 
         # Poor man's canonicalization of external indices.
@@ -2224,24 +2258,26 @@ class _Optimizer:
         #
         # TODO: Fix it!
 
-        chosen = min(candidates.items(), key=lambda x: (
-            len(x[1]), -len(x[0].amp.atoms(Symbol) & new_dumms),
-            x[0].sort_key
-        ))
+        chosen = min(
+            candidates.items(),
+            key=lambda x: (
+                len(x[1]),
+                -len(x[0].amp.atoms(Symbol) & new_dumms),
+                x[0].sort_key,
+            ),
+        )
 
         canon_new_sums = set(i for i, _ in chosen[1])
         if len(canon_new_sums) > 1:
             warnings.warn(
-                'Internal deficiency: '
-                'summation intermediate may not be fully canonicalized'
+                "Internal deficiency: "
+                "summation intermediate may not be fully canonicalized"
             )
         # This could also fail when the chosen term has symmetry among the new
         # summations not present in any other term.  This can be hard to check.
 
         canon_new_sum = canon_new_sums.pop()
-        preferred = prod_(
-            coeffs[i] for _, i in candidates[chosen[0]]
-        )
+        preferred = prod_(coeffs[i] for _, i in candidates[chosen[0]])
         canon_coeff = _get_canon_coeff(coeffs, preferred)
 
         res_terms = []
@@ -2251,9 +2287,11 @@ class _Optimizer:
             res_terms.append(canon_term.map(lambda x: x / canon_coeff))
             continue
 
-        return canon_coeff, tuple(
-            sorted(res_terms, key=lambda x: x.sort_key)
-        ), canon_new_sum
+        return (
+            canon_coeff,
+            tuple(sorted(res_terms, key=lambda x: x.sort_key)),
+            canon_new_sum,
+        )
 
     def _canon_term(self, new_sums, term, fix_new=False):
         """Canonicalize a single term.
@@ -2261,16 +2299,24 @@ class _Optimizer:
         Internal method for _canon_terms, not supposed to be directly called.
         """
 
-        term = Term(tuple(itertools.chain(
-            (
-                (v[0], v[1].replace_label((v[1].label[0], _EXT, i)))
-                for i, v in enumerate(new_sums)
-            ) if fix_new else new_sums,
-            (
-                (i, j.replace_label((j.label, _SUMMED)))
-                for i, j in term.sums
-            )
-        )), term.amp, ())
+        term = Term(
+            tuple(
+                itertools.chain(
+                    (
+                        (v[0], v[1].replace_label((v[1].label[0], _EXT, i)))
+                        for i, v in enumerate(new_sums)
+                    )
+                    if fix_new
+                    else new_sums,
+                    (
+                        (i, j.replace_label((j.label, _SUMMED)))
+                        for i, j in term.sums
+                    ),
+                )
+            ),
+            term.amp,
+            (),
+        )
         canoned = term.canon(symms=self._drudge.symms.value)
 
         canon_sums = canoned.sums
@@ -2299,13 +2345,12 @@ class _Optimizer:
                 i_new += 1
             continue
 
-        return dumm_reset.map(sums=tuple(itertools.chain(
-            term_new_sums, term_sums
-        ))), tuple(canon_new_sums)
+        return dumm_reset.map(
+            sums=tuple(itertools.chain(term_new_sums, term_sums))
+        ), tuple(canon_new_sums)
 
     def _parse_interm_ref(self, expr: Expr) -> typing.Optional[_IntermRef]:
-        """Parse an expression that is possibly an intermediate reference.
-        """
+        """Parse an expression that is possibly an intermediate reference."""
 
         coeff = _UNITY
         base = None
@@ -2333,8 +2378,12 @@ class _Optimizer:
             else:
                 coeff *= i
 
-        return None if base is None else _IntermRef(
-            coeff=coeff, base=base, indices=indices, power=power
+        return (
+            None
+            if base is None
+            else _IntermRef(
+                coeff=coeff, base=base, indices=indices, power=power
+            )
         )
 
     def _get_content(self, interm_ref: Expr) -> typing.List[Term]:
@@ -2383,16 +2432,16 @@ class _Optimizer:
 
         substs, excl = node.get_substs(indices)
 
-        term = Term(
-            node.sums, node.coeff * prod_(node.factors), ()
-        ).reset_dumms(
-            self._dumms, excl=self._excl | excl
-        )[0].map(lambda x: x.xreplace(substs))
+        term = (
+            Term(node.sums, node.coeff * prod_(node.factors), ())
+            .reset_dumms(self._dumms, excl=self._excl | excl)[0]
+            .map(lambda x: x.xreplace(substs))
+        )
 
         return [term]
 
     def _raise_power(
-            self, terms: typing.Sequence[Term], exp: int
+        self, terms: typing.Sequence[Term], exp: int
     ) -> typing.List[Term]:
         """Raise the sum of the given terms to the given power."""
         curr = []  # type: typing.List[Term]
@@ -2401,10 +2450,14 @@ class _Optimizer:
                 curr = list(terms)
             else:
                 # TODO: Make the multiplication more efficient.
-                curr = [i.mul_term(
-                    j, dumms=self._dumms,
-                    excl=self._excl | i.free_vars | j.free_vars
-                ) for i, j in itertools.product(curr, terms)]
+                curr = [
+                    i.mul_term(
+                        j,
+                        dumms=self._dumms,
+                        excl=self._excl | i.free_vars | j.free_vars,
+                    )
+                    for i, j in itertools.product(curr, terms)
+                ]
         return curr
 
     #
@@ -2423,12 +2476,10 @@ class _Optimizer:
 
         if len(terms) == 0:
             raise ValueError(
-                'Tensor is constant zero, probably it is not what you meant',
-                grain.base
+                "Tensor is constant zero, probably it is not what you meant",
+                grain.base,
             )
-        return self._form_sum_from_terms(
-            grain.base, exts, terms
-        )
+        return self._form_sum_from_terms(grain.base, exts, terms)
 
     def _optimize(self, node):
         """Optimize the evaluation of the given node.
@@ -2457,15 +2508,12 @@ class _Optimizer:
         """
 
         decored_exts = tuple(
-            (i, j.replace_label((j.label, _EXT)))
-            for i, j in exts
+            (i, j.replace_label((j.label, _EXT))) for i, j in exts
         )
         n_exts = len(decored_exts)
         term = Term(tuple(sums), prod_(factors).simplify(), ())
 
-        coeff, key, canon_exts = self._canon_terms(
-            decored_exts, [term]
-        )
+        coeff, key, canon_exts = self._canon_terms(decored_exts, [term])
         assert len(key) == 1
 
         if key in self._interms_canon:
@@ -2481,25 +2529,21 @@ class _Optimizer:
             # The external symbols will automatically be considered in
             # get_amp_factors since they are in the summation list right now.
             key_factors, key_coeff = key_term.get_amp_factors(self._interms)
-            interm = _Prod(
-                base, key_exts, key_sums, key_coeff, key_factors
-            )
+            interm = _Prod(base, key_exts, key_sums, key_coeff, key_factors)
             self._interms[base] = interm
 
         return _Interm(
             ref=coeff * _index(base, canon_exts, strip=True),
-            node=self._interms[base]
+            node=self._interms[base],
         )
 
     def _form_sum_interm(
-            self, exts: _SrPairs, terms: typing.Sequence[Term]
+        self, exts: _SrPairs, terms: typing.Sequence[Term]
     ) -> _Interm:
-        """Form a sum intermediate.
-        """
+        """Form a sum intermediate."""
 
         decored_exts = tuple(
-            (i, j.replace_label((j.label, _EXT)))
-            for i, j in exts
+            (i, j.replace_label((j.label, _EXT))) for i, j in exts
         )
         n_exts = len(decored_exts)
 
@@ -2528,11 +2572,11 @@ class _Optimizer:
 
         return _Interm(
             ref=coeff * _index(base, canon_exts, strip=True),
-            node=self._interms[base]
+            node=self._interms[base],
         )
 
     def _form_sum_from_terms(
-            self, base: Symbol, exts: _SrPairs, terms: typing.Iterable[Term]
+        self, base: Symbol, exts: _SrPairs, terms: typing.Iterable[Term]
     ):
         """Form a summation node for given the terms.
 
@@ -2577,16 +2621,13 @@ class _Optimizer:
             old_terms = self._optimize_common_symmtrization(old_terms, exts)
 
         res_terms = scalars + old_terms + new_terms
-        sum_node.evals = [_Sum(
-            sum_node.base, sum_node.exts, res_terms
-        )]
+        sum_node.evals = [_Sum(sum_node.base, sum_node.exts, res_terms)]
         return
 
-    def _organize_sum_terms(self, terms: typing.Iterable[Expr]) -> typing.Tuple[
-        typing.List[Expr], typing.List[Expr], _OrgTerms
-    ]:
-        """Organize terms in the summation node.
-        """
+    def _organize_sum_terms(
+        self, terms: typing.Iterable[Expr]
+    ) -> typing.Tuple[typing.List[Expr], typing.List[Expr], _OrgTerms]:
+        """Organize terms in the summation node."""
 
         # Intermediate base -> (indices -> coefficient)
         #
@@ -2614,17 +2655,14 @@ class _Optimizer:
             for indices, coeff in v.items():
                 coeff = coeff.simplify()
                 if coeff != 0:
-                    res_terms.append(
-                        _index(k, indices) * coeff
-                    )
+                    res_terms.append(_index(k, indices) * coeff)
 
             continue
 
         return plain_scalars, res_terms, org_terms
 
     def _optimize_common_symmtrization(self, terms, exts):
-        """Optimize common symmetrization in the intermediate references.
-        """
+        """Optimize common symmetrization in the intermediate references."""
 
         res_terms = []
         exts_dict = dict(exts)
@@ -2634,14 +2672,11 @@ class _Optimizer:
         # Indices, coeffs tuple -> base, coeff
         pull_info = collections.defaultdict(list)
         for k, v in org_terms.items():
-
             if len(v) == 0:
                 assert False
             elif len(v) == 1:
                 indices, coeff = v.popitem()
-                res_terms.append(
-                    _index(k, indices) * coeff
-                )
+                res_terms.append(_index(k, indices) * coeff)
             else:
                 # Here we use name for sorting directly, since here we cannot
                 # have general expressions hence no need to use the expensive
@@ -2649,9 +2684,9 @@ class _Optimizer:
                 raw = list(v.items())  # Indices/coefficient pairs.
                 raw.sort(key=lambda x: [i.name for i in x[0]])
                 leading_coeff = raw[0][1]
-                pull_info[tuple(
-                    (i, j / leading_coeff) for i, j in raw
-                )].append((k, leading_coeff))
+                pull_info[
+                    tuple((i, j / leading_coeff) for i, j in raw)
+                ].append((k, leading_coeff))
 
         # Now we treat the terms from which new intermediates might be pulled
         # out.
@@ -2665,9 +2700,7 @@ class _Optimizer:
                 pivot_ref = _index(base, pivot) * coeff
             else:
                 # We need to form an intermediate here.
-                interm_exts = tuple(
-                    (i, exts_dict[i]) for i in pivot
-                )
+                interm_exts = tuple((i, exts_dict[i]) for i in pivot)
                 interm_terms = [
                     term.scale(coeff)
                     for base, coeff in v
@@ -2680,23 +2713,16 @@ class _Optimizer:
                 self._optimize(interm_node)
 
             for indices, coeff in k:
-                substs = {
-                    i: j for i, j in zip(pivot, indices)
-                }
-                res_terms.append(
-                    pivot_ref.xreplace(substs) * coeff
-                )
+                substs = {i: j for i, j in zip(pivot, indices)}
+                res_terms.append(pivot_ref.xreplace(substs) * coeff)
                 continue
 
             continue
 
         return res_terms
 
-    def constr_sum(
-            self, terms: typing.Sequence[Expr], exts: _SrPairs
-    ):
-        """Constrict the summations greedily.
-        """
+    def constr_sum(self, terms: typing.Sequence[Expr], exts: _SrPairs):
+        """Constrict the summations greedily."""
 
         if_untouched = (1 << len(terms)) - 1
         new_terms = []
@@ -2704,14 +2730,13 @@ class _Optimizer:
         constr_graphs = self._form_constr_graphs(terms, exts)
 
         while True:
-
             last_step_idxes, biclique = constr_graphs.get_opt_biclique()
             if last_step_idxes is None:
                 break
 
-            new_terms.append(self._form_constred_term(
-                last_step_idxes, biclique
-            ))
+            new_terms.append(
+                self._form_constred_term(last_step_idxes, biclique)
+            )
             if_untouched = constr_graphs.cleanup_constred(
                 if_untouched, biclique
             )
@@ -2725,7 +2750,7 @@ class _Optimizer:
         return new_terms, untouched_terms
 
     def _form_constr_graphs(
-            self, terms: typing.Sequence[Expr], exts: _SrPairs
+        self, terms: typing.Sequence[Expr], exts: _SrPairs
     ) -> _ConstrGraphs:
         """Form the constriction graphs for the terms.
 
@@ -2777,11 +2802,14 @@ class _Optimizer:
         return constr_graphs
 
     def _aug_constr_graphs_4_eval(
-            self, res: _ConstrGraphs, term_idx: int, ref: _IntermRef,
-            eval_: _Prod, exts: _SrPairs
+        self,
+        res: _ConstrGraphs,
+        term_idx: int,
+        ref: _IntermRef,
+        eval_: _Prod,
+        exts: _SrPairs,
     ):
-        """Augment the constriction graphs for an evaluation.
-        """
+        """Augment the constriction graphs for an evaluation."""
 
         if len(eval_.factors) < 2:
             return
@@ -2793,16 +2821,16 @@ class _Optimizer:
 
         ext_symbs = {i for i, _ in eval_.exts}
 
-        factors, coeff = eval_term.get_amp_factors(
-            self._interms, ext_symbs
-        )
+        factors, coeff = eval_term.get_amp_factors(self._interms, ext_symbs)
         coeff *= ref.coeff
         assert len(factors) == 2
         assert factors[0] != factors[1]
 
-        sums = tuple(sorted(
-            eval_term.sums, key=lambda x: (x[1], default_sort_key(x[0]))
-        ))
+        sums = tuple(
+            sorted(
+                eval_term.sums, key=lambda x: (x[1], default_sort_key(x[0]))
+            )
+        )
 
         excl = set(self._excl)
         excl.update(ext_symbs)
@@ -2816,12 +2844,10 @@ class _Optimizer:
             content = content[0]
 
             symbs = f_i.atoms(Symbol)
-            exts_idxes = tuple(
-                i for i, v in enumerate(exts) if v[0] in symbs
+            exts_idxes = tuple(i for i, v in enumerate(exts) if v[0] in symbs)
+            exts_int = functools.reduce(
+                operator.or_, (1 << i for i in exts_idxes), 0
             )
-            exts_int = functools.reduce(operator.or_, (
-                1 << i for i in exts_idxes
-            ), 0)
 
             for i, _ in sums:
                 assert i in symbs
@@ -2832,18 +2858,16 @@ class _Optimizer:
                 self._dumms, excl=excl | content.free_vars
             )[0]
 
-            _, canon_coeff = canon.get_amp_factors(
-                self._interms, ext_symbs
-            )
-            canon = canon.map(
-                lambda x: x / canon_coeff, skip_vecs=True
-            )
+            _, canon_coeff = canon.get_amp_factors(self._interms, ext_symbs)
+            canon = canon.map(lambda x: x / canon_coeff, skip_vecs=True)
             coeff *= canon_coeff
 
-            factor_infos.append((
-                tuple(exts[i] for i in exts_idxes),
-                _VertInfo(exts=exts_int, expr=f_i, canon=canon)
-            ))
+            factor_infos.append(
+                (
+                    tuple(exts[i] for i in exts_idxes),
+                    _VertInfo(exts=exts_int, expr=f_i, canon=canon),
+                )
+            )
             continue
 
         factor_infos.sort(key=lambda x: x[1].exts)
@@ -2862,13 +2886,15 @@ class _Optimizer:
 
         constr_graph.add_edge(
             (factor_infos[0][1], factor_infos[1][1]),
-            coeff=coeff, term=term_idx, eval_=eval_
+            coeff=coeff,
+            term=term_idx,
+            eval_=eval_,
         )
 
         return
 
     def _form_constred_term(
-            self, last_step_idxes: _LastStepIdxes, biclique: _Biclique
+        self, last_step_idxes: _LastStepIdxes, biclique: _Biclique
     ) -> Expr:
         """Form the factored term for the given constriction."""
 
@@ -2877,9 +2903,7 @@ class _Optimizer:
         # Form and optimize the two new summation nodes.
         factors = [biclique.leading_coeff]
         for exts_i, part_i in zip(last_step_idxes.exts, biclique.parts):
-            scaled_terms = [
-                verts[i]['info'].canon.scale(j) for i, j in part_i
-            ]
+            scaled_terms = [verts[i]["info"].canon.scale(j) for i, j in part_i]
 
             exts = tuple(itertools.chain(exts_i, last_step_idxes.sums))
 
@@ -2895,10 +2919,12 @@ class _Optimizer:
             continue
 
         # Form the contraction node for the two new summation nodes.
-        exts = tuple(sorted(
-            set(itertools.chain.from_iterable(last_step_idxes.exts)),
-            key=lambda x: default_sort_key(x[0])
-        ))
+        exts = tuple(
+            sorted(
+                set(itertools.chain.from_iterable(last_step_idxes.exts)),
+                key=lambda x: default_sort_key(x[0]),
+            )
+        )
         expr, eval_node = self._form_prod_interm(
             exts, last_step_idxes.sums, factors
         )
@@ -2914,8 +2940,7 @@ class _Optimizer:
     #
 
     def _optimize_prod(self, prod_node):
-        """Optimize the product evaluation node.
-        """
+        """Optimize the product evaluation node."""
 
         # This function should not be called on an already-optimized node.
         assert len(prod_node.evals) == 0
@@ -2950,7 +2975,7 @@ class _Optimizer:
         factors_with = collections.defaultdict(list)
         for i, v in enumerate(factors):
             for dim in sorted(
-                    dumm2dim[j] for j in v.atoms(Symbol) if j in dumm2dim
+                dumm2dim[j] for j in v.atoms(Symbol) if j in dumm2dim
             ):
                 factors_with[dim].append(i)
                 continue
@@ -2978,9 +3003,9 @@ class _Optimizer:
             for i in dims_in_chunk:
                 total_size *= dims[cat][i][1].size
                 continue
-            dim_chunks.append(Tuple4Cmp((
-                (cat, total_size), dims_in_chunk, fs)
-            ))
+            dim_chunks.append(
+                Tuple4Cmp(((cat, total_size), dims_in_chunk, fs))
+            )
             continue
         dim_chunks.sort()
         # Now the dimension chunks finally got their index for libparenth.
@@ -3008,8 +3033,7 @@ class _Optimizer:
             assert 0
 
         if_inclusive = (
-                contr_strat == ContrStrat.TRAV or
-                contr_strat == ContrStrat.EXHAUST
+            contr_strat == ContrStrat.TRAV or contr_strat == ContrStrat.EXHAUST
         )
 
         #
@@ -3023,12 +3047,13 @@ class _Optimizer:
         # Translate the result back.
         #
         # Here a small memoir is used to cache the result.
-        get_orig_dims = functools.partial(self._get_orig_dims, dims, dim_chunks)
+        get_orig_dims = functools.partial(
+            self._get_orig_dims, dims, dim_chunks
+        )
         interms: typing.Dict[typing.Tuple[int, ...], _Interm] = {}
 
         def form_interm(factor_idxes) -> _Interm:
-            """Form the intermediate for parenthesizing the given factors.
-            """
+            """Form the intermediate for parenthesizing the given factors."""
 
             if factor_idxes in interms:
                 return interms[factor_idxes]
@@ -3089,8 +3114,7 @@ class _Optimizer:
 
             # Translation from the current dummy symbol to the canonical symbol.
             to_canon = {
-                i: j[0]
-                for i, j in zip(target_ref.indices, target_node.exts)
+                i: j[0] for i, j in zip(target_ref.indices, target_node.exts)
             }
             # Here the sum indices in the evaluation is going to be renamed
             # according the to sum indices in the target node, since they are
@@ -3124,15 +3148,15 @@ class _Optimizer:
                 for curr_dumm, range_ in eval_sums:
                     new_dumm = canon_sum_dumms[range_][sum_idx[range_]]
                     sum_idx[range_] += 1
-                    res_sums.append((
-                        new_dumm, range_
-                    ))
+                    res_sums.append((new_dumm, range_))
                     to_canon[curr_dumm] = new_dumm
 
                 eval_node = _Prod(
-                    target_node.base, target_node.exts, res_sums,
+                    target_node.base,
+                    target_node.exts,
+                    res_sums,
                     (coeff / target_ref.coeff).xreplace(to_canon),
-                    [i.xreplace(to_canon) for i in fs]
+                    [i.xreplace(to_canon) for i in fs],
                 )
                 eval_node.total_cost = eval_.cost
 
@@ -3170,8 +3194,9 @@ class _Optimizer:
 
 
 def verify_eval_seq(
-        eval_seq: typing.Sequence[TensorDef], res: typing.Sequence[TensorDef],
-        simplify=False
+    eval_seq: typing.Sequence[TensorDef],
+    res: typing.Sequence[TensorDef],
+    simplify=False,
 ) -> bool:
     """Verify the correctness of an evaluation sequence for the results.
 
@@ -3208,9 +3233,7 @@ def verify_eval_seq(
     for idx, eval_ in enumerate(eval_seq):
         base = eval_.base
         free_vars = eval_.rhs.free_vars
-        curr_defs = [
-            defs_dict[i] for i in free_vars if i in defs_dict
-        ]
+        curr_defs = [defs_dict[i] for i in free_vars if i in defs_dict]
         exts = {i for i, _ in eval_.exts}
         rhs = eval_.rhs.subst_all(curr_defs, simplify=simplify, excl=exts)
         new_def = TensorDef(base, eval_.exts, rhs)
@@ -3234,17 +3257,19 @@ def verify_eval_seq(
             ref_exts = [i for i, _ in ref.exts]
             if len(new_exts) != len(ref_exts):
                 raise ValueError(
-                    'Unequal number of external indices for ', base,
-                    new_exts, ref_exts
+                    "Unequal number of external indices for ",
+                    base,
+                    new_exts,
+                    ref_exts,
                 )
 
-            new_res = new_def if new_exts == ref_exts else new_def[
-                tuple(ref_exts)
-            ]
+            new_res = (
+                new_def if new_exts == ref_exts else new_def[tuple(ref_exts)]
+            )
 
             diff = (new_res - ref.rhs).simplify()
             if diff != 0:
-                raise ValueError('Unequal definition for ', base)
+                raise ValueError("Unequal definition for ", base)
             del res_dict[base]
         else:
             # For intermediates.
@@ -3255,8 +3280,6 @@ def verify_eval_seq(
         continue
 
     if len(res_dict) != 0:
-        raise ValueError(
-            'Computation not given for', list(res_dict.keys())
-        )
+        raise ValueError("Computation not given for", list(res_dict.keys()))
 
     return True

--- a/gristmill/utils.py
+++ b/gristmill/utils.py
@@ -6,9 +6,7 @@ import re
 import typing
 
 import numpy as np
-from jinja2 import (
-    Environment, PackageLoader, ChoiceLoader, DictLoader
-)
+from jinja2 import Environment, PackageLoader, ChoiceLoader, DictLoader
 from numpy.polynomial import Polynomial
 from sympy import Symbol, Integer, Mul, poly_from_expr, Number, Poly, Expr
 
@@ -21,6 +19,7 @@ from drudge import prod_, TensorDef, Range
 #
 # Numeric cost manipulation during optimization.
 #
+
 
 class SVPoly(Polynomial):
     """Single variate polynomials for sizes and costs.
@@ -72,7 +71,7 @@ class SVPoly(Polynomial):
         """Test if a cost is a positive/negative one."""
 
         coeff = self.coef
-        inf_idxes, = np.where(np.isinf(coeff))
+        (inf_idxes,) = np.where(np.isinf(coeff))
         if inf_idxes.size == 0:
             idx = -1
         else:
@@ -103,8 +102,9 @@ def form_size(expr: Expr) -> typing.Tuple[Size, typing.Optional[Symbol]]:
         coeff_exprs.reverse()
     else:
         raise ValueError(
-            'Invalid expression', expr,
-            'expecting single variate polynomial (or number)'
+            "Invalid expression",
+            expr,
+            "expecting single variate polynomial (or number)",
         )
 
     if all(i.is_integer for i in coeff_exprs):
@@ -145,8 +145,7 @@ def get_total_size(sums) -> Size:
         curr = i.size
         if curr is None:
             raise ValueError(
-                'Invalid range for optimization', i,
-                'expecting a bound range.'
+                "Invalid range for optimization", i, "expecting a bound range."
             )
         size *= curr
         continue
@@ -162,9 +161,7 @@ class SizedRange(Range):
     faster equality and hashing.
     """
 
-    __slots__ = [
-        '_size'
-    ]
+    __slots__ = ["_size"]
 
     def __init__(self, label, size):
         """Initialize the sized range object."""
@@ -190,9 +187,9 @@ class SizedRange(Range):
         return (self._size, self._label)
 
 
-def form_sized_range(range_: Range, substs) -> typing.Tuple[
-    SizedRange, typing.Optional[Symbol]
-]:
+def form_sized_range(
+    range_: Range, substs
+) -> typing.Tuple[SizedRange, typing.Optional[Symbol]]:
     """Form a sized range from the original raw range.
 
     The when a symbol exists in the ranges, it will be returned as the second
@@ -201,13 +198,11 @@ def form_sized_range(range_: Range, substs) -> typing.Tuple[
 
     if not range_.bounded:
         raise ValueError(
-            'Invalid range for optimization', range_,
-            'expecting explicit bound'
+            "Invalid range for optimization",
+            range_,
+            "expecting explicit bound",
         )
-    lower, upper = [
-        i.xreplace(substs)
-        for i in [range_.lower, range_.upper]
-    ]
+    lower, upper = [i.xreplace(substs) for i in [range_.lower, range_.upper]]
     size_expr = upper - lower
 
     size, symb = form_size(size_expr)
@@ -241,8 +236,7 @@ class Tuple4Cmp(tuple):
 
 
 def get_flop_cost(
-        eval_seq: typing.Iterable[TensorDef], leading=False,
-        ignore_consts=True
+    eval_seq: typing.Iterable[TensorDef], leading=False, ignore_consts=True
 ):
     """Get the FLOP cost for the given evaluation sequence.
 
@@ -325,7 +319,7 @@ def _get_leading(cost):
 
     leading_deg = max(sum(i) for i, _ in terms)
     leading_cost = sum(
-        coeff * prod_(i ** j for i, j in zip(symbs, degs))
+        coeff * prod_(i**j for i, j in zip(symbs, degs))
         for degs, coeff in terms
         if sum(degs) == leading_deg
     )
@@ -337,6 +331,7 @@ def _get_leading(cost):
 # Disjoint set forest
 # -------------------
 #
+
 
 class DSF(object):
     """
@@ -378,7 +373,6 @@ class DSF(object):
 
         represent = None  # The set that other sets will be unioned to.
         for i in contents:
-
             if represent is None:
                 represent = i
             else:
@@ -394,8 +388,7 @@ class DSF(object):
 
     @property
     def n_sets(self):
-        """The number of sets in the forest.
-        """
+        """The number of sets in the forest."""
         return self._n_sets
 
     def union_two(self, idx1, idx2):
@@ -484,19 +477,28 @@ class JinjaEnv(Environment):
     """
 
     def __init__(
-            self, indent=' ' * 4, breakable_regex=None, max_width=80,
-            line_cont='', cont_indent=1, add_filters=None, add_globals=None,
-            add_tests=None, add_templ=None
+        self,
+        indent=" " * 4,
+        breakable_regex=None,
+        max_width=80,
+        line_cont="",
+        cont_indent=1,
+        add_filters=None,
+        add_globals=None,
+        add_tests=None,
+        add_templ=None,
     ):
         """Initialize the Jinja environment."""
 
         # Set the Jinja environment up.
         super().__init__(
-            trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True,
+            trim_blocks=True,
+            lstrip_blocks=True,
+            keep_trailing_newline=True,
             loader=ChoiceLoader(
-                [PackageLoader('gristmill')] +
-                ([DictLoader(add_templ)] if add_templ is not None else [])
-            )
+                [PackageLoader("gristmill")]
+                + ([DictLoader(add_templ)] if add_templ is not None else [])
+            ),
         )
 
         self._indent = indent
@@ -506,14 +508,14 @@ class JinjaEnv(Environment):
         self._cont_indent = cont_indent
 
         # Add the default filters and tests for all printers.
-        self.globals['indent'] = indent
-        self.globals['line_cont'] = line_cont
-        self.globals['cont_indent'] = cont_indent
+        self.globals["indent"] = indent
+        self.globals["line_cont"] = line_cont
+        self.globals["cont_indent"] = cont_indent
 
-        self.filters['form_indent'] = self.form_indent
-        self.filters['wrap_line'] = self.wrap_line
+        self.filters["form_indent"] = self.form_indent
+        self.filters["wrap_line"] = self.wrap_line
 
-        self.tests['non_empty'] = self.non_empty
+        self.tests["non_empty"] = self.non_empty
 
         # Add the additional globals, filters, and tests.
         if add_globals is not None:
@@ -574,9 +576,9 @@ class JinjaEnv(Environment):
         for idx, token in enumerate(tokens):
             new_len = curr_len + len(token)
             if_add = (
-                    len(curr_line) == 0
-                    or (idx + 1 == n_tokens and new_len <= max_width)
-                    or new_len + len(line_cont) <= max_width
+                len(curr_line) == 0
+                or (idx + 1 == n_tokens and new_len <= max_width)
+                or new_len + len(line_cont) <= max_width
             )
             if if_add:
                 curr_line.append(token)
@@ -584,16 +586,16 @@ class JinjaEnv(Environment):
             else:
                 # When the current line is already filled up.
                 curr_line.append(line_cont)
-                lines.append(''.join(curr_line))
+                lines.append("".join(curr_line))
                 curr_line = [cont_indent]
                 curr_len = len(cont_indent)
             # Go on to the next token.
             continue
 
         # We need to add the trailing current line after all the loop.
-        lines.append(''.join(curr_line))
+        lines.append("".join(curr_line))
 
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     @staticmethod
     def non_empty(sequence):
@@ -607,6 +609,4 @@ class JinjaEnv(Environment):
         """
 
         indent = self.form_indent(level)
-        return '\n'.join(
-            indent + i for i in lines.splitlines()
-        ) + '\n'
+        return "\n".join(indent + i for i in lines.splitlines()) + "\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ dev = ["pytest", "juliacall>=0.9.20"]
 
 [project.urls]
 Homepage = "https://github.com/DrudgeCAS/gristmill"
+
+[dependency-groups]
+dev = [
+  "ruff>=0.16.2",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,17 +9,19 @@ import os
 import pytest
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def spark_ctx():
     """A simple spark context."""
 
-    if 'DUMMY_SPARK' in os.environ:
+    if "DUMMY_SPARK" in os.environ:
         from dummy_spark import SparkConf, SparkContext
+
         conf = SparkConf()
-        ctx = SparkContext(master='', conf=conf)
+        ctx = SparkContext(master="", conf=conf)
     else:
         from pyspark import SparkConf, SparkContext
-        conf = SparkConf().setMaster('local[2]').setAppName('drudge-unittest')
+
+        conf = SparkConf().setMaster("local[2]").setAppName("drudge-unittest")
         ctx = SparkContext(conf=conf)
 
     return ctx

--- a/tests/opt_cc_test.py
+++ b/tests/opt_cc_test.py
@@ -1,16 +1,19 @@
-"""Tests about optimizations of problems from coupled-cluster theories.
-"""
+"""Tests about optimizations of problems from coupled-cluster theories."""
 
 import pytest
 from drudge import PartHoleDrudge
 from sympy import IndexedBase, Symbol, Rational
 
 from gristmill import (
-    optimize, verify_eval_seq, ContrStrat, get_flop_cost, RepeatedTermsStrat
+    optimize,
+    verify_eval_seq,
+    ContrStrat,
+    get_flop_cost,
+    RepeatedTermsStrat,
 )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def parthole_drudge(spark_ctx):
     """The particle-hold drudge."""
     dr = PartHoleDrudge(spark_ctx)
@@ -30,16 +33,16 @@ def test_ccd_doubles_terms(parthole_drudge):
     a, b, c, d = p.V_dumms[:4]
     i, j, k, l = p.O_dumms[:4]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
-    r = IndexedBase('r')
+    r = IndexedBase("r")
     tensor = dr.define_einst(
         r[a, b, i, j],
-        + t[a, b, l, j] * t[c, d, i, k] * u[k, l, c, d]
+        +t[a, b, l, j] * t[c, d, i, k] * u[k, l, c, d]
         + t[a, d, i, j] * t[b, c, k, l] * u[k, l, c, d]
         - t[a, b, i, l] * t[c, d, k, j] * u[k, l, c, d]
-        - t[a, c, k, l] * t[b, d, i, j] * u[k, l, c, d]
+        - t[a, c, k, l] * t[b, d, i, j] * u[k, l, c, d],
     )
     targets = [tensor]
 
@@ -62,15 +65,16 @@ def test_ccsd_singles_terms(parthole_drudge):
     i, j, k = p.O_dumms[:3]
     u = dr.two_body
     f = dr.fock
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
-    r = IndexedBase('r')
+    r = IndexedBase("r")
     tensor = dr.define_einst(
         r[a, i],
-        t[a, b, i, j] * u[j, k, b, c] * t[c, k] + t[a, b, i, j] * f[j, b]
+        t[a, b, i, j] * u[j, k, b, c] * t[c, k]
+        + t[a, b, i, j] * f[j, b]
         - t[a, j] * t[b, i] * f[j, b]
-        - t[a, j] * t[b, i] * t[c, k] * u[j, k, b, c]
+        - t[a, j] * t[b, i] * t[c, k] * u[j, k, b, c],
     )
     targets = [tensor]
 
@@ -94,12 +98,12 @@ def test_ccsd_energy(parthole_drudge):
     a, b = p.V_dumms[:2]
     i, j = p.O_dumms[:2]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
 
     energy = dr.define_einst(
-        Symbol('e'),
+        Symbol("e"),
         u[i, j, a, b] * t[a, b, i, j] * Rational(1, 2)
-        + u[i, j, a, b] * t[a, i] * t[b, j]
+        + u[i, j, a, b] * t[a, i] * t[b, j],
     )
     targets = [energy]
 
@@ -134,12 +138,12 @@ def test_ccsd_doubles(parthole_drudge):
     a, b, c, d = p.V_dumms[:4]
     i, j = p.O_dumms[:2]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
     tensor = dr.define_einst(
-        IndexedBase('r')[a, b, i, j],
-        t[c, d, i, j] * u[a, b, c, d] + u[a, b, c, d] * t[c, i] * t[d, j]
+        IndexedBase("r")[a, b, i, j],
+        t[c, d, i, j] * u[a, b, c, d] + u[a, b, c, d] * t[c, i] * t[d, j],
     )
     targets = [tensor]
 
@@ -178,54 +182,53 @@ def test_ccsd_doubles_complex_terms(parthole_drudge):
     a, b, c, d = p.V_dumms[:4]
     i, j, k, l = p.O_dumms[:4]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
     tau = dr.define_einst(
-        IndexedBase('tau')[a, b, i, j],
-        Rational(1, 2) * t[a, b, i, j] + t[a, i] * t[b, j]
+        IndexedBase("tau")[a, b, i, j],
+        Rational(1, 2) * t[a, b, i, j] + t[a, i] * t[b, j],
     )
 
     a_i = dr.define_einst(
-        IndexedBase('AI')[k, l, i, j], u[i, c, k, l] * t[c, j]
+        IndexedBase("AI")[k, l, i, j], u[i, c, k, l] * t[c, j]
     )
 
     a_ = dr.define(
-        IndexedBase('A')[k, l, i, j],
-        u[k, l, i, j] +
-        a_i[k, l, i, j] - a_i[k, l, j, i]
-        + u[k, l, c, d] * tau[c, d, i, j]
+        IndexedBase("A")[k, l, i, j],
+        u[k, l, i, j]
+        + a_i[k, l, i, j]
+        - a_i[k, l, j, i]
+        + u[k, l, c, d] * tau[c, d, i, j],
     )
 
     a_term = dr.einst(a_[k, l, i, j] * tau[a, b, k, l])
 
     b_i = dr.define_einst(
-        IndexedBase('BI')[a, b, c, d], u[a, k, c, d] * t[b, k]
+        IndexedBase("BI")[a, b, c, d], u[a, k, c, d] * t[b, k]
     )
 
     b_ = dr.define_einst(
-        IndexedBase('B')[a, b, c, d],
-        u[a, b, c, d] - b_i[a, b, c, d] + b_i[b, a, c, d]
+        IndexedBase("B")[a, b, c, d],
+        u[a, b, c, d] - b_i[a, b, c, d] + b_i[b, a, c, d],
     )
 
     b_term = dr.einst(b_[a, b, c, d] * tau[c, d, i, j])
 
-    substs = {
-        p.no: 1000,
-        p.nv: 1100
-    }
+    substs = {p.no: 1000, p.nv: 1100}
 
     # Simple a term or b term should work well both with full backtrack and
     # greedily.  But repeated terms need to be ignored for full factorization.
     for term in [a_term, b_term]:
-        tensor = dr.define_einst(IndexedBase('r')[a, b, i, j], term)
+        tensor = dr.define_einst(IndexedBase("r")[a, b, i, j], term)
         targets = [tensor]
         for drop_cutoff in [-1, 2]:
             eval_seq = optimize(
-                targets, substs=substs,
+                targets,
+                substs=substs,
                 contr_strat=ContrStrat.EXHAUST,
                 repeated_terms_strat=RepeatedTermsStrat.IGNORE,
-                drop_cutoff=drop_cutoff
+                drop_cutoff=drop_cutoff,
             )
             assert verify_eval_seq(eval_seq, targets)
             # Here we just assert that the final step is a simple product.
@@ -244,25 +247,29 @@ def test_ccsd_pij_term(parthole_drudge):
     a, b, c, d = p.V_dumms[:4]
     i, j, k, l = p.O_dumms[:4]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     dr.set_dbbar_base(t, 2)
 
-    r = IndexedBase('r')
-    f = IndexedBase('f')
+    r = IndexedBase("r")
+    f = IndexedBase("f")
 
-    targets = [dr.define_einst(
-        r[a, b, i, j],
-        - 2 * t[c, l] * t[b, a, k, i] * u[k, l, c, j]
-        + 2 * f[k, i] * t[a, b, k, j]
-        - 2 * t[c, i] * u[a, b, c, j]
-        + t[b, a, k, i] * t[c, d, j, l] * u[k, l, c, d]
-        - 2 * t[c, l] * t[d, j] * t[b, a, k, i] * u[k, l, c, d]
-        + 2 * f[k, c] * t[c, j] * t[b, a, k, i]
-    )]
+    targets = [
+        dr.define_einst(
+            r[a, b, i, j],
+            -2 * t[c, l] * t[b, a, k, i] * u[k, l, c, j]
+            + 2 * f[k, i] * t[a, b, k, j]
+            - 2 * t[c, i] * u[a, b, c, j]
+            + t[b, a, k, i] * t[c, d, j, l] * u[k, l, c, d]
+            - 2 * t[c, l] * t[d, j] * t[b, a, k, i] * u[k, l, c, d]
+            + 2 * f[k, c] * t[c, j] * t[b, a, k, i],
+        )
+    ]
 
     drop_cutoff = -1
     eval_seq = optimize(
-        targets, substs={p.nv: p.no * 1.1},
-        contr_strat=ContrStrat.EXHAUST, drop_cutoff=drop_cutoff
+        targets,
+        substs={p.nv: p.no * 1.1},
+        contr_strat=ContrStrat.EXHAUST,
+        drop_cutoff=drop_cutoff,
     )
     verify_eval_seq(eval_seq, targets)

--- a/tests/opt_matrix_test.py
+++ b/tests/opt_matrix_test.py
@@ -27,23 +27,20 @@ def three_ranges(spark_ctx):
     dr = Drudge(spark_ctx)
 
     # The sizes.
-    m, n, l = symbols('m n l')
+    m, n, l = symbols("m n l")
 
     # The ranges.
-    m_range = Range('M', 0, m)
-    n_range = Range('N', 0, n)
-    l_range = Range('L', 0, l)
+    m_range = Range("M", 0, m)
+    n_range = Range("N", 0, n)
+    l_range = Range("L", 0, l)
 
-    dr.set_dumms(m_range, symbols('a b c d e f g'))
-    dr.set_dumms(n_range, symbols('i j k l m n'))
-    dr.set_dumms(l_range, symbols('p q r'))
+    dr.set_dumms(m_range, symbols("a b c d e f g"))
+    dr.set_dumms(n_range, symbols("i j k l m n"))
+    dr.set_dumms(l_range, symbols("p q r"))
     dr.add_resolver_for_dumms()
     dr.set_name(m, n, l)
 
-    dr.substs = {
-        n: m * 2,
-        l: m * 3
-    }
+    dr.substs = {n: m * 2, l: m * 3}
 
     return dr
 
@@ -71,21 +68,20 @@ def test_matrix_chain(three_ranges):
     m, n, l = p.m, p.n, p.l
 
     # The indexed bases.
-    x = IndexedBase('x', shape=(m, n))
-    y = IndexedBase('y', shape=(n, l))
-    z = IndexedBase('z', shape=(l, m))
+    x = IndexedBase("x", shape=(m, n))
+    y = IndexedBase("y", shape=(n, l))
+    z = IndexedBase("z", shape=(l, m))
 
-    target_base = IndexedBase('t')
+    target_base = IndexedBase("t")
     target = dr.define_einst(
-        target_base[p.a, p.b],
-        x[p.a, p.i] * y[p.i, p.p] * z[p.p, p.b]
+        target_base[p.a, p.b], x[p.a, p.i] * y[p.i, p.p] * z[p.p, p.b]
     )
 
     # Perform the factorization.
     targets = [target]
     stats = {}
     eval_seq = optimize(targets, substs=dr.substs, stats=stats)
-    assert stats['Number of nodes'] < 2 ** 3
+    assert stats["Number of nodes"] < 2**3
     assert len(eval_seq) == 2
 
     # Check the correctness.
@@ -94,12 +90,12 @@ def test_matrix_chain(three_ranges):
     # Check the cost.
     cost = get_flop_cost(eval_seq)
     leading_cost = get_flop_cost(eval_seq, leading=True)
-    expected_cost = 2 * l * m * n + 2 * m ** 2 * n
+    expected_cost = 2 * l * m * n + 2 * m**2 * n
     assert cost == expected_cost
     assert leading_cost == expected_cost
 
 
-@pytest.mark.parametrize('rand_constr', [True, False])
+@pytest.mark.parametrize("rand_constr", [True, False])
 def test_shallow_matrix_factorization(three_ranges, rand_constr):
     """Test a shallow matrix multiplication factorization problem.
 
@@ -126,20 +122,22 @@ def test_shallow_matrix_factorization(three_ranges, rand_constr):
     p = dr.names
 
     m = p.m
-    a, b, c, d = p.a, p.b, p.c, p.d
+    a, b, c = p.a, p.b, p.c
 
     # The indexed bases.
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    u = IndexedBase('U')
-    v = IndexedBase('V')
-    t = IndexedBase('T')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    u = IndexedBase("U")
+    v = IndexedBase("V")
+    t = IndexedBase("T")
 
     # The target.
     target = dr.define_einst(
         t[a, b],
-        4 * x[a, c] * u[c, b] + 2 * x[a, c] * v[c, b]
-        - 2 * y[a, c] * u[c, b] - y[a, c] * v[c, b]
+        4 * x[a, c] * u[c, b]
+        + 2 * x[a, c] * v[c, b]
+        - 2 * y[a, c] * u[c, b]
+        - y[a, c] * v[c, b],
     )
     targets = [target]
 
@@ -153,10 +151,10 @@ def test_shallow_matrix_factorization(three_ranges, rand_constr):
     # Test the cost.
     cost = get_flop_cost(res)
     leading_cost = get_flop_cost(res, leading=True)
-    assert cost == 2 * m ** 3 + 2 * m ** 2
-    assert leading_cost == 2 * m ** 3
+    assert cost == 2 * m**3 + 2 * m**2
+    assert leading_cost == 2 * m**3
     cost = get_flop_cost(res, ignore_consts=False)
-    assert cost == 2 * m ** 3 + 4 * m ** 2
+    assert cost == 2 * m**3 + 4 * m**2
 
 
 def test_deep_matrix_factorization(three_ranges):
@@ -186,11 +184,11 @@ def test_deep_matrix_factorization(three_ranges):
     a, b, c, d = p.a, p.b, p.c, p.d
 
     # The indexed bases.
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    u = IndexedBase('U')
-    v = IndexedBase('V')
-    t = IndexedBase('T')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    u = IndexedBase("U")
+    v = IndexedBase("V")
+    t = IndexedBase("T")
 
     # The target.
     target = dr.define_einst(
@@ -208,10 +206,10 @@ def test_deep_matrix_factorization(three_ranges):
     # Test the cost.
     cost = get_flop_cost(res)
     leading_cost = get_flop_cost(res, leading=True)
-    assert cost == 4 * m ** 3 + m ** 2
-    assert leading_cost == 4 * m ** 3
+    assert cost == 4 * m**3 + m**2
+    assert leading_cost == 4 * m**3
     cost = get_flop_cost(res, ignore_consts=False)
-    assert cost == 4 * m ** 3 + 2 * m ** 2
+    assert cost == 4 * m**3 + 2 * m**2
 
     # Test disabling summation optimization.
     res = optimize(targets, opt_sum=False)
@@ -245,18 +243,20 @@ def test_factorization_of_two_products(three_ranges):
     a, b, c = p.a, p.b, p.c
 
     # The indexed bases.
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    u = IndexedBase('U')
-    v = IndexedBase('V')
-    t = IndexedBase('T')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    u = IndexedBase("U")
+    v = IndexedBase("V")
+    t = IndexedBase("T")
 
     # The target.
     target = dr.define_einst(
-        IndexedBase('r')[a, b],
-        6 * x[a, c] * u[c, b] + 10 * x[a, c] * v[c, b]
-        - 77 * y[a, c] * u[c, b] - 91 * y[a, c] * v[c, b]
-        + 17 * t[a, b]
+        IndexedBase("r")[a, b],
+        6 * x[a, c] * u[c, b]
+        + 10 * x[a, c] * v[c, b]
+        - 77 * y[a, c] * u[c, b]
+        - 91 * y[a, c] * v[c, b]
+        + 17 * t[a, b],
     )
     targets = [target]
 
@@ -270,7 +270,7 @@ def test_factorization_of_two_products(three_ranges):
 
     # Test the cost.
     cost = get_flop_cost(res)
-    assert cost == 4 * m ** 3 + 4 * m ** 2
+    assert cost == 4 * m**3 + 4 * m**2
 
 
 def test_general_matrix_problem(three_ranges):
@@ -296,25 +296,24 @@ def test_general_matrix_problem(three_ranges):
     dr = three_ranges
     p = dr.names
 
-    m, n, l = p.m, p.n, p.l
+    m = p.m
     a, b = p.a, p.b
     i = p.i
     p = p.p
 
-    f1 = IndexedBase('A')[a, i] + 2 * IndexedBase('B')[a, i]
-    f2 = 3 * IndexedBase('C')[i, p] + 5 * IndexedBase('D')[i, p]
-    f3 = 7 * IndexedBase('E')[p, b] + 13 * IndexedBase('F')[p, b]
-    f4 = 17 * IndexedBase('P')[a, i] + 19 * IndexedBase('Q')[a, i]
-    f5 = 23 * IndexedBase('X')[i, b] + 29 * IndexedBase('Y')[i, b]
+    f1 = IndexedBase("A")[a, i] + 2 * IndexedBase("B")[a, i]
+    f2 = 3 * IndexedBase("C")[i, p] + 5 * IndexedBase("D")[i, p]
+    f3 = 7 * IndexedBase("E")[p, b] + 13 * IndexedBase("F")[p, b]
+    f4 = 17 * IndexedBase("P")[a, i] + 19 * IndexedBase("Q")[a, i]
+    f5 = 23 * IndexedBase("X")[i, b] + 29 * IndexedBase("Y")[i, b]
 
     target = dr.define_einst(
-        IndexedBase('R')[a, b],
-        (f1 * f2 * f3 + f4 * f5).expand()
+        IndexedBase("R")[a, b], (f1 * f2 * f3 + f4 * f5).expand()
     )
     targets = [target]
     assert target.n_terms == 12
     assert get_flop_cost(targets).subs(dr.substs) == (
-            144 * m ** 4 + 16 * m ** 3 + 11 * m ** 2
+        144 * m**4 + 16 * m**3 + 11 * m**2
     )
 
     eval_seq = optimize(targets, substs=dr.substs)
@@ -323,7 +322,7 @@ def test_general_matrix_problem(three_ranges):
     assert verify_eval_seq(eval_seq, targets)
     assert len(eval_seq) == 7
     cost = get_flop_cost(eval_seq)
-    assert cost.subs(dr.substs) == 20 * m ** 3 + 16 * m ** 2
+    assert cost.subs(dr.substs) == 20 * m**3 + 16 * m**2
 
 
 #
@@ -333,26 +332,24 @@ def test_general_matrix_problem(three_ranges):
 
 
 def test_disconnected_outer_product_factorization(three_ranges):
-    """Test optimization of expressions with disconnected outer products.
-    """
+    """Test optimization of expressions with disconnected outer products."""
 
     dr = three_ranges
     p = dr.names
 
     m = p.m
-    a, b, c, d, e = p.a, p.b, p.c, p.d, p.e
+    a, b, c, e = p.a, p.b, p.c, p.e
 
     # The indexed bases.
-    u = IndexedBase('U')
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    z = IndexedBase('Z')
-    t = IndexedBase('T')
+    u = IndexedBase("U")
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    z = IndexedBase("Z")
+    t = IndexedBase("T")
 
     # The target.
     target = dr.define_einst(
-        t[a, b],
-        u[a, b] * z[c, e] * x[e, c] + u[a, b] * z[c, e] * y[e, c]
+        t[a, b], u[a, b] * z[c, e] * x[e, c] + u[a, b] * z[c, e] * y[e, c]
     )
     targets = [target]
 
@@ -366,8 +363,8 @@ def test_disconnected_outer_product_factorization(three_ranges):
     # Test the cost.
     cost = get_flop_cost(res)
     leading_cost = get_flop_cost(res, leading=True)
-    assert cost == 4 * m ** 2
-    assert leading_cost == 4 * m ** 2
+    assert cost == 4 * m**2
+    assert leading_cost == 4 * m**2
 
 
 def test_factorization_needing_canonicalization(three_ranges):
@@ -380,18 +377,15 @@ def test_factorization_needing_canonicalization(three_ranges):
     dr = three_ranges
     p = dr.names
 
-    m = p.m
     a, b = p.a, p.b
 
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    z = IndexedBase('Z')
-    t = Symbol('T')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    z = IndexedBase("Z")
+    t = Symbol("T")
 
     # The target.
-    target = dr.define_einst(
-        t, x[b, a] * z[a, b] + y[a, b] * z[b, a]
-    )
+    target = dr.define_einst(t, x[b, a] * z[a, b] + y[a, b] * z[b, a])
     targets = [target]
 
     # The actual optimization.
@@ -433,14 +427,13 @@ def test_optimization_of_common_terms(three_ranges):
     dr = three_ranges
     p = dr.names
 
-    a, b, c, d = p.a, p.b, p.c, p.d
+    a, b = p.a, p.b
 
     # The indexed bases.
-    x = IndexedBase('x')
-    y = IndexedBase('y')
+    x = IndexedBase("x")
+    y = IndexedBase("y")
     t = dr.define_einst(
-        IndexedBase('t')[a, b],
-        x[a, b] - x[b, a] + 2 * y[a, b] - 2 * y[b, a]
+        IndexedBase("t")[a, b], x[a, b] - x[b, a] + 2 * y[a, b] - 2 * y[b, a]
     )
 
     targets = [t]
@@ -485,28 +478,22 @@ def test_eval_compression(three_ranges):
     i, j, k = p.i, p.j, p.k  # Big range
 
     # The indexed bases.
-    u = IndexedBase('U')
-    v = IndexedBase('V')
-    w = IndexedBase('W')
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
+    u = IndexedBase("U")
+    v = IndexedBase("V")
+    w = IndexedBase("W")
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
 
-    s = IndexedBase('S')
-    t1 = IndexedBase('T1')
-    t2 = IndexedBase('T2')
+    s = IndexedBase("S")
+    t1 = IndexedBase("T1")
+    t2 = IndexedBase("T2")
 
     # The target.
-    s_def = dr.define_einst(
-        s[i, j],
-        u[i, k] * x[k, j] + u[i, k] * y[k, j]
-    )
-    targets = [dr.define_einst(
-        t1[i, j],
-        s_def[i, a] * v[a, j]
-    ), dr.define_einst(
-        t2[i, j],
-        s_def[i, a] * w[a, j]
-    )]
+    s_def = dr.define_einst(s[i, j], u[i, k] * x[k, j] + u[i, k] * y[k, j])
+    targets = [
+        dr.define_einst(t1[i, j], s_def[i, a] * v[a, j]),
+        dr.define_einst(t2[i, j], s_def[i, a] * w[a, j]),
+    ]
 
     # The actual optimization.
     res = optimize(targets, substs=dr.substs)
@@ -516,7 +503,7 @@ def test_eval_compression(three_ranges):
     assert verify_eval_seq(res, targets, simplify=False)
 
 
-@pytest.mark.parametrize('res_at_end', [True, False])
+@pytest.mark.parametrize("res_at_end", [True, False])
 def test_interleaving_res_interm(three_ranges, res_at_end):
     r"""Test the interleaving of results and intermediates.
 
@@ -543,10 +530,10 @@ def test_interleaving_res_interm(three_ranges, res_at_end):
     p = dr.names
     a, b, c, d, e = p.a, p.b, p.c, p.d, p.e
 
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    r1 = IndexedBase('R1')
-    r2 = IndexedBase('R2')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    r1 = IndexedBase("R1")
+    r2 = IndexedBase("R2")
 
     r1_def = dr.define_einst(r1[a, b], x[a, c] * y[c, b] * 2)
     r2_def = dr.define_einst(r2[a, b], x[a, c] * y[c, b] * x[d, e] * y[e, d])
@@ -564,5 +551,5 @@ def test_interleaving_res_interm(three_ranges, res_at_end):
     assert eval_seq[3].base == r2
 
     for i in eval_seq:
-        assert i.if_interm == (not (str(i.base)[0] == 'R'))
+        assert i.if_interm == (not (str(i.base)[0] == "R"))
         continue

--- a/tests/opt_misc_test.py
+++ b/tests/opt_misc_test.py
@@ -1,5 +1,4 @@
-"""Test optimization of different special kinds of tensor computations.
-"""
+"""Test optimization of different special kinds of tensor computations."""
 
 import pytest
 from drudge import Drudge, Range, TensorDef
@@ -8,7 +7,7 @@ from sympy import symbols, Symbol, IndexedBase, conjugate
 from gristmill import optimize, verify_eval_seq, get_flop_cost, ContrStrat
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def simple_drudge(spark_ctx):
     """Make simple drudge.
 
@@ -17,9 +16,9 @@ def simple_drudge(spark_ctx):
 
     dr = Drudge(spark_ctx)
 
-    n = symbols('n')
-    r = Range('r', 0, n)
-    dumms = symbols('a b c d e f g h')
+    n = symbols("n")
+    r = Range("r", 0, n)
+    dumms = symbols("a b c d e f g h")
     dr.set_dumms(r, dumms)
     dr.add_default_resolver(r)
 
@@ -45,8 +44,8 @@ def test_summation_shared_by_four_factors(simple_drudge):
     dr = simple_drudge
     a = dr.ds[0]
 
-    x, y, z, w = (IndexedBase(i) for i in ['x', 'y', 'z', 'w'])
-    targets = [dr.define_einst(Symbol('s'), x[a] * y[a] * z[a] * w[a])]
+    x, y, z, w = (IndexedBase(i) for i in ["x", "y", "z", "w"])
+    targets = [dr.define_einst(Symbol("s"), x[a] * y[a] * z[a] * w[a])]
 
     costs = []
     for strat in ContrStrat:
@@ -73,16 +72,17 @@ def test_constriction_over_an_outer_product(simple_drudge):
     n = dr.n
     a, b = dr.ds[:2]
 
-    A, X = IndexedBase('A'), IndexedBase('X')
-    y, z = IndexedBase('y'), IndexedBase('z')
+    A, X = IndexedBase("A"), IndexedBase("X")
+    y, z = IndexedBase("y"), IndexedBase("z")
 
-    targets = [dr.define_einst(
-        Symbol('e'), A[a, b] * X[a, b] + A[a, b] * y[a] * z[b])]
+    targets = [
+        dr.define_einst(Symbol("e"), A[a, b] * X[a, b] + A[a, b] * y[a] * z[b])
+    ]
 
     eval_seq = optimize(targets)
 
     assert verify_eval_seq(eval_seq, targets)
-    assert get_flop_cost(eval_seq) == 4 * n ** 2
+    assert get_flop_cost(eval_seq) == 4 * n**2
 
 
 def test_constriction_over_three_terms(simple_drudge):
@@ -100,19 +100,22 @@ def test_constriction_over_three_terms(simple_drudge):
     n = dr.n
     a, b = dr.ds[:2]
 
-    X = IndexedBase('X')
-    y, z, u = (IndexedBase(i) for i in ['y', 'z', 'u'])
+    X = IndexedBase("X")
+    y, z, u = (IndexedBase(i) for i in ["y", "z", "u"])
 
-    targets = [dr.define_einst(
-        Symbol('e'),
-        X[a, b] * z[a] * y[b]
-        + 2 * X[a, b] * y[a] * y[b]
-        - X[a, b] * u[a] * y[b])]
+    targets = [
+        dr.define_einst(
+            Symbol("e"),
+            X[a, b] * z[a] * y[b]
+            + 2 * X[a, b] * y[a] * y[b]
+            - X[a, b] * u[a] * y[b],
+        )
+    ]
 
     eval_seq = optimize(targets)
 
     assert verify_eval_seq(eval_seq, targets)
-    assert get_flop_cost(eval_seq) == 2 * n ** 2 + 4 * n
+    assert get_flop_cost(eval_seq) == 2 * n**2 + 4 * n
 
 
 def test_constriction_search_is_not_pruned_unsoundly(simple_drudge):
@@ -132,19 +135,22 @@ def test_constriction_search_is_not_pruned_unsoundly(simple_drudge):
     n = dr.n
     a, b = dr.ds[:2]
 
-    P = IndexedBase('P')
-    z, u, w = (IndexedBase(i) for i in ['z', 'u', 'w'])
+    P = IndexedBase("P")
+    z, u, w = (IndexedBase(i) for i in ["z", "u", "w"])
 
-    targets = [dr.define_einst(
-        Symbol('res'),
-        -P[a, b] * z[a] * u[b]
-        + P[a, b] * u[a] * w[b]
-        + 3 * P[a, b] * w[a] * u[b])]
+    targets = [
+        dr.define_einst(
+            Symbol("res"),
+            -P[a, b] * z[a] * u[b]
+            + P[a, b] * u[a] * w[b]
+            + 3 * P[a, b] * w[a] * u[b],
+        )
+    ]
 
     eval_seq = optimize(targets)
 
     assert verify_eval_seq(eval_seq, targets)
-    assert get_flop_cost(eval_seq) == 4 * n ** 2 + 4 * n
+    assert get_flop_cost(eval_seq) == 4 * n**2 + 4 * n
 
 
 def test_sum_with_an_index_free_product(simple_drudge):
@@ -159,18 +165,21 @@ def test_sum_with_an_index_free_product(simple_drudge):
     dr = simple_drudge
     a, b, c = dr.ds[:3]
 
-    q_mat, v = IndexedBase('Q'), IndexedBase('V')
-    q, s = IndexedBase('q'), IndexedBase('s')
-    targets = [dr.define_einst(
-        Symbol('res'),
-        q_mat[a, b] * q[a] * s[b]
-        + 2 * q_mat[a, b] * q_mat[a, b]
-        - q_mat[a, b] * v[a, c] * v[c, b]
-    )]
+    q_mat, v = IndexedBase("Q"), IndexedBase("V")
+    q, s = IndexedBase("q"), IndexedBase("s")
+    targets = [
+        dr.define_einst(
+            Symbol("res"),
+            q_mat[a, b] * q[a] * s[b]
+            + 2 * q_mat[a, b] * q_mat[a, b]
+            - q_mat[a, b] * v[a, c] * v[c, b],
+        )
+    ]
 
     for strat in ContrStrat:
         eval_seq = optimize(targets, contr_strat=strat)
         assert verify_eval_seq(eval_seq, targets)
+
 
 def test_simple_scalar_optimization(spark_ctx):
     """Test optimization of a simple scalar.
@@ -181,28 +190,30 @@ def test_simple_scalar_optimization(spark_ctx):
 
     dr = Drudge(spark_ctx)
 
-    a, b, r = symbols('a b r')
+    a, b, r = symbols("a b r")
     targets = [dr.define(r, a * b)]
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
 
 
 def test_conjugation_optimization(simple_drudge):
-    """Test optimization of expressions containing complex conjugate.
-    """
+    """Test optimization of expressions containing complex conjugate."""
 
     dr = simple_drudge
 
     a, b, c, d = dr.ds[:4]
 
-    p = IndexedBase('p')
-    x = IndexedBase('x')
-    y = IndexedBase('y')
-    z = IndexedBase('z')
+    p = IndexedBase("p")
+    x = IndexedBase("x")
+    y = IndexedBase("y")
+    z = IndexedBase("z")
 
-    targets = [dr.define_einst(
-        p[a, b], x[a, c] * conjugate(y[c, b]) + x[a, c] * conjugate(z[c, b])
-    )]
+    targets = [
+        dr.define_einst(
+            p[a, b],
+            x[a, c] * conjugate(y[c, b]) + x[a, c] * conjugate(z[c, b]),
+        )
+    ]
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
 
@@ -218,13 +229,13 @@ def test_optimization_handles_coeffcients(simple_drudge):
 
     a, b = dr.ds[:2]
 
-    r = IndexedBase('r')
-    eps = IndexedBase('epsilon')
-    t = IndexedBase('t')
+    r = IndexedBase("r")
+    eps = IndexedBase("epsilon")
+    t = IndexedBase("t")
 
-    targets = [dr.define(r[a, b], dr.sum(
-        2 * eps[a] * t[a, b]
-    ) - 2 * eps[b] * t[a, b])]
+    targets = [
+        dr.define(r[a, b], dr.sum(2 * eps[a] * t[a, b]) - 2 * eps[b] * t[a, b])
+    ]
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
 
@@ -241,16 +252,20 @@ def test_optimization_handles_scalar_intermediates(simple_drudge):
     r = dr.r
     a, b, c = dr.ds[:3]
 
-    u = IndexedBase('u')
-    eps = IndexedBase('epsilon')
-    t = IndexedBase('t')
-    s = IndexedBase('s')
+    u = IndexedBase("u")
+    eps = IndexedBase("epsilon")
+    t = IndexedBase("t")
+    s = IndexedBase("s")
 
-    targets = [dr.define(
-        u, (a, r), (b, r),
-        dr.sum((c, r), 8 * s[a, b] * eps[c] * t[a])
-        - 8 * s[a, b] * eps[a] * t[a]
-    )]
+    targets = [
+        dr.define(
+            u,
+            (a, r),
+            (b, r),
+            dr.sum((c, r), 8 * s[a, b] * eps[c] * t[a])
+            - 8 * s[a, b] * eps[a] * t[a],
+        )
+    ]
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
 
@@ -266,34 +281,41 @@ def test_optimization_handles_nonlinear_factors(simple_drudge):
     r = dr.r
     a, b, c, d = dr.ds[:4]
 
-    u = symbols('u')
-    s = IndexedBase('s')
+    u = symbols("u")
+    s = IndexedBase("s")
 
-    targets = [dr.define(u, dr.sum(
-        (a, r), (b, r), (c, r), (d, r),
-        32 * s[a, c] ** 2 * s[b, d] ** 2 +
-        32 * s[a, c] * s[a, d] * s[b, c] * s[b, d]
-    ))]
+    targets = [
+        dr.define(
+            u,
+            dr.sum(
+                (a, r),
+                (b, r),
+                (c, r),
+                (d, r),
+                32 * s[a, c] ** 2 * s[b, d] ** 2
+                + 32 * s[a, c] * s[a, d] * s[b, c] * s[b, d],
+            ),
+        )
+    ]
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
 
 
 def test_common_summation_intermediate_recognition(simple_drudge):
-    """Test recognition of summation intermediate differing only in a scalar.
-    """
+    """Test recognition of summation intermediate differing only in a scalar."""
 
     dr = simple_drudge
 
     a, b, c = dr.ds[:3]
 
-    x = IndexedBase('x')
-    y = IndexedBase('y')
-    p = IndexedBase('p')
-    q = IndexedBase('q')
-    r = IndexedBase('r')
-    s = IndexedBase('s')
+    x = IndexedBase("x")
+    y = IndexedBase("y")
+    p = IndexedBase("p")
+    q = IndexedBase("q")
+    r = IndexedBase("r")
+    s = IndexedBase("s")
 
-    alpha = symbols('alpha')
+    alpha = symbols("alpha")
 
     for c1, c2, c3, c4 in [
         (1, 1, 1, 1),
@@ -301,17 +323,15 @@ def test_common_summation_intermediate_recognition(simple_drudge):
         (1, 1, -1, -1),
         (1, -2, -1, 2),
         (1, -1, -1, 1),
-        (1, -alpha, 2, -2 * alpha)
+        (1, -alpha, 2, -2 * alpha),
     ]:
         targets = [
             dr.define_einst(
-                r[a, b],
-                c1 * p[a, c] * x[c, b] + c2 * p[a, c] * y[c, b]
+                r[a, b], c1 * p[a, c] * x[c, b] + c2 * p[a, c] * y[c, b]
             ),
             dr.define_einst(
-                s[a, b],
-                c3 * q[a, c] * x[c, b] + c4 * q[a, c] * y[c, b]
-            )
+                s[a, b], c3 * q[a, c] * x[c, b] + c4 * q[a, c] * y[c, b]
+            ),
         ]
 
         eval_seq = optimize(targets)
@@ -328,60 +348,58 @@ def test_removal_of_shallow_interms(simple_drudge):
     r = dr.r
     a, b, c, d = dr.ds[:4]
 
-    x = IndexedBase('x')
-    y = IndexedBase('y')
-    z = IndexedBase('z')
-    u = IndexedBase('u')
+    x = IndexedBase("x")
+    y = IndexedBase("y")
+    z = IndexedBase("z")
+    u = IndexedBase("u")
 
     targets = [
         dr.define(
-            u, (a, r), (b, r), (c, r),
-            dr.sum((d, r), x[a, d] * y[b, d] * z[c, d])
+            u,
+            (a, r),
+            (b, r),
+            (c, r),
+            dr.sum((d, r), x[a, d] * y[b, d] * z[c, d]),
         )
     ]
 
     for i in [True, False]:
         eval_seq = optimize(targets, remove_shallow=i)
         verify_eval_seq(eval_seq, targets)
-        assert len(eval_seq) == (
-            1 if i else 2
-        )
+        assert len(eval_seq) == (1 if i else 2)
         continue
 
 
 def test_get_cost_on_zero_cost(simple_drudge):
-    """Test correct behaviour of get_flop_cost at input with no FLOP cost.
-    """
+    """Test correct behaviour of get_flop_cost at input with no FLOP cost."""
 
     dr = simple_drudge
 
     a, b = dr.ds[:2]
 
-    x = IndexedBase('x')
-    r = IndexedBase('y')
+    x = IndexedBase("x")
+    r = IndexedBase("y")
 
-    targets = [
-        dr.define_einst(x[a, b], r[a, b])
-    ]
+    targets = [dr.define_einst(x[a, b], r[a, b])]
 
-    for i in [
-        get_flop_cost(targets),
-        get_flop_cost(targets, leading=True)
-    ]:
+    for i in [get_flop_cost(targets), get_flop_cost(targets, leading=True)]:
         assert i == 0
         continue
 
 
-@pytest.mark.parametrize('ext_names,sum_name', [
-    ('a b', 'c'),
-    ('a b', 'e'),
-    ('b c', 'd'),
-    ('c d', 'e'),
-    ('f g', 'h'),
-    ('g h', 'a'),
-])
+@pytest.mark.parametrize(
+    "ext_names,sum_name",
+    [
+        ("a b", "c"),
+        ("a b", "e"),
+        ("b c", "d"),
+        ("c d", "e"),
+        ("f g", "h"),
+        ("g h", "a"),
+    ],
+)
 def test_verification_of_a_result_with_any_external_symbols(
-        simple_drudge, ext_names, sum_name
+    simple_drudge, ext_names, sum_name
 ):
     """Verification must not depend on which symbols the caller used.
 
@@ -400,14 +418,15 @@ def test_verification_of_a_result_with_any_external_symbols(
     i0, i1 = symbols(ext_names)
     k = symbols(sum_name)
 
-    x = IndexedBase('X')
-    y, z, u = (IndexedBase(i) for i in ['Y', 'Z', 'U'])
-    res = IndexedBase('res')
+    x = IndexedBase("X")
+    y, z, u = (IndexedBase(i) for i in ["Y", "Z", "U"])
+    res = IndexedBase("res")
 
-    targets = [dr.define_einst(
-        res[i0, i1],
-        x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1]
-    )]
+    targets = [
+        dr.define_einst(
+            res[i0, i1], x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1]
+        )
+    ]
 
     eval_seq = optimize(targets)
     assert verify_eval_seq(eval_seq, targets)
@@ -422,17 +441,19 @@ def test_verification_still_rejects_a_wrong_result(simple_drudge):
 
     dr = simple_drudge
 
-    x = IndexedBase('X')
-    y, z, u = (IndexedBase(i) for i in ['Y', 'Z', 'U'])
-    res = IndexedBase('res')
+    x = IndexedBase("X")
+    y, z, u = (IndexedBase(i) for i in ["Y", "Z", "U"])
+    res = IndexedBase("res")
 
-    for ext_names, sum_name in [('a b', 'c'), ('c d', 'e')]:
+    for ext_names, sum_name in [("a b", "c"), ("c d", "e")]:
         i0, i1 = symbols(ext_names)
         k = symbols(sum_name)
-        targets = [dr.define_einst(
-            res[i0, i1],
-            x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1]
-        )]
+        targets = [
+            dr.define_einst(
+                res[i0, i1],
+                x[i0, k] * y[k, i1] + x[i0, k] * z[k, i1] + u[i0, i1],
+            )
+        ]
 
         eval_seq = list(optimize(targets))
         assert verify_eval_seq(eval_seq, targets)

--- a/tests/opt_order_test.py
+++ b/tests/opt_order_test.py
@@ -33,8 +33,9 @@ def _looks_like_memoir(items):
             return False
         key = entry[0]
         if not (
-                isinstance(key, tuple) and key
-                and all(isinstance(i, int) for i in key)
+            isinstance(key, tuple)
+            and key
+            and all(isinstance(i, int) for i in key)
         ):
             return False
     return True
@@ -49,11 +50,11 @@ def _walk_memoir(monkeypatch, order):
 
     def patched(iterable, **kwargs):
         items = list(iterable)
-        if kwargs.get('reverse') and _looks_like_memoir(items):
+        if kwargs.get("reverse") and _looks_like_memoir(items):
             return order(_REAL_SORTED(items))
         return _REAL_SORTED(items, **kwargs)
 
-    monkeypatch.setattr(gristmill.optimize, 'sorted', patched, raising=False)
+    monkeypatch.setattr(gristmill.optimize, "sorted", patched, raising=False)
 
 
 def _shuffled(seed):
@@ -66,18 +67,18 @@ def _shuffled(seed):
 
 
 ORDERS = {
-    'descending': lambda items: list(reversed(items)),
-    'ascending': lambda items: list(items),
-    'by_size': lambda items: _REAL_SORTED(
+    "descending": lambda items: list(reversed(items)),
+    "ascending": lambda items: list(items),
+    "by_size": lambda items: _REAL_SORTED(
         items, key=lambda x: (len(x[0]), x[0])
     ),
-    'shuffle_1': _shuffled(1),
-    'shuffle_2': _shuffled(2),
-    'shuffle_3': _shuffled(3),
+    "shuffle_1": _shuffled(1),
+    "shuffle_2": _shuffled(2),
+    "shuffle_3": _shuffled(3),
 }
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def problems(spark_ctx):
     """The problems whose answer used to depend on the walk order.
 
@@ -94,39 +95,39 @@ def problems(spark_ctx):
     a, b = p.V_dumms[:2]
     i, j = p.O_dumms[:2]
     u = dr.two_body
-    t = IndexedBase('t')
+    t = IndexedBase("t")
     energy = dr.define_einst(
-        Symbol('e'),
+        Symbol("e"),
         u[i, j, a, b] * t[a, b, i, j] * Rational(1, 2)
-        + u[i, j, a, b] * t[a, i] * t[b, j]
+        + u[i, j, a, b] * t[a, i] * t[b, j],
     )
-    res['ccsd_energy'] = ([energy], {p.nv: p.no * 10}, 2)
+    res["ccsd_energy"] = ([energy], {p.nv: p.no * 10}, 2)
 
     # Two matrix problems.
     dr = Drudge(spark_ctx)
-    m = symbols('m')
-    r = Range('M', 0, m)
-    dumms = symbols('a b c d e f g h')
+    m = symbols("m")
+    r = Range("M", 0, m)
+    dumms = symbols("a b c d e f g h")
     dr.set_dumms(r, dumms)
     dr.add_default_resolver(r)
     a, b, c, e = dumms[0], dumms[1], dumms[2], dumms[4]
-    u, x, y, z = (IndexedBase(i) for i in ['U', 'X', 'Y', 'Z'])
+    u, x, y, z = (IndexedBase(i) for i in ["U", "X", "Y", "Z"])
 
     target = dr.define_einst(
-        IndexedBase('T')[a, b],
-        u[a, b] * z[c, e] * x[e, c] + u[a, b] * z[c, e] * y[e, c]
+        IndexedBase("T")[a, b],
+        u[a, b] * z[c, e] * x[e, c] + u[a, b] * z[c, e] * y[e, c],
     )
-    res['disconnected_outer_product'] = ([target], {}, 3)
+    res["disconnected_outer_product"] = ([target], {}, 3)
 
     target = dr.define_einst(
-        Symbol('T'), x[b, a] * z[a, b] + y[a, b] * z[b, a]
+        Symbol("T"), x[b, a] * z[a, b] + y[a, b] * z[b, a]
     )
-    res['needing_canonicalization'] = ([target], {}, 2)
+    res["needing_canonicalization"] = ([target], {}, 2)
 
     return res
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def reference(problems):
     """The result of the production walk, for comparison."""
 
@@ -139,9 +140,9 @@ def reference(problems):
     return res
 
 
-@pytest.mark.parametrize('order', list(ORDERS))
+@pytest.mark.parametrize("order", list(ORDERS))
 def test_memoir_walk_order_does_not_change_the_result(
-        monkeypatch, problems, reference, order
+    monkeypatch, problems, reference, order
 ):
     """The result must be the same under any walk of the memoir."""
 
@@ -164,19 +165,20 @@ def test_rand_constr_gives_random_constrictions(spark_ctx):
     """
 
     dr = Drudge(spark_ctx)
-    n = symbols('n')
-    r = Range('r', 0, n)
-    dr.set_dumms(r, symbols('a b c d'))
+    n = symbols("n")
+    r = Range("r", 0, n)
+    dr.set_dumms(r, symbols("a b c d"))
     dr.add_default_resolver(r)
-    a, b = symbols('a b')
+    a, b = symbols("a b")
 
-    xs = [IndexedBase('x%d' % i) for i in range(3)]
-    ys = [IndexedBase('y%d' % i) for i in range(3)]
+    xs = [IndexedBase("x%d" % i) for i in range(3)]
+    ys = [IndexedBase("y%d" % i) for i in range(3)]
     amp = sum(
         (i + 2 * j + 1) * xs[i][a, b] * ys[j][a, b]
-        for i in range(3) for j in range(3)
+        for i in range(3)
+        for j in range(3)
     )
-    targets = [dr.define_einst(Symbol('r'), amp)]
+    targets = [dr.define_einst(Symbol("r"), amp)]
 
     seen = set()
     for seed in range(8):
@@ -210,15 +212,15 @@ def test_unrelated_term_does_not_disturb_the_rest(spark_ctx):
     """
 
     dr = Drudge(spark_ctx)
-    n = symbols('n')
-    r = Range('r', 0, n)
-    dr.set_dumms(r, symbols('a b c d e f g h'))
+    n = symbols("n")
+    r = Range("r", 0, n)
+    dr.set_dumms(r, symbols("a b c d e f g h"))
     dr.add_default_resolver(r)
-    a, b = symbols('a b')
+    a, b = symbols("a b")
 
-    x = IndexedBase('X')
-    y, z, u = (IndexedBase(i) for i in ['y', 'z', 'u'])
-    p, q = IndexedBase('P'), IndexedBase('Q')
+    x = IndexedBase("X")
+    y, z, u = (IndexedBase(i) for i in ["y", "z", "u"])
+    p, q = IndexedBase("P"), IndexedBase("Q")
 
     core = (
         x[a, b] * z[a] * y[b]
@@ -228,7 +230,7 @@ def test_unrelated_term_does_not_disturb_the_rest(spark_ctx):
     extra = p[a, b] * q[a, b]
 
     def cost(amp, strat):
-        targets = [dr.define_einst(Symbol('e'), amp)]
+        targets = [dr.define_einst(Symbol("e"), amp)]
         eval_seq = optimize(targets, contr_strat=strat)
         assert verify_eval_seq(eval_seq, targets)
         return get_flop_cost(eval_seq)

--- a/tests/parenth_test.py
+++ b/tests/parenth_test.py
@@ -10,8 +10,8 @@ import pytest
 from gristmill._parenth import parenth
 
 
-@pytest.mark.parametrize('mode', [0, 1, 2])
-@pytest.mark.parametrize('if_incl', [False, True])
+@pytest.mark.parametrize("mode", [0, 1, 2])
+@pytest.mark.parametrize("if_incl", [False, True])
 def test_factor_without_indices(mode, if_incl):
     """A single factor with no index at all gives the trivial memoir.
 

--- a/tests/printers_test.py
+++ b/tests/printers_test.py
@@ -1,31 +1,44 @@
-"""Tests for the base printer.
-"""
+"""Tests for the base printer."""
 
 import subprocess
 from unittest.mock import patch
 
 import pytest
-from sympy import Symbol, IndexedBase, symbols, Float
+
+# Float looks unused, but the tests below eval printed numerators, and those
+# strings name it.
+from sympy import Symbol, IndexedBase, symbols, Float  # noqa: F401
 from sympy.printing.python import PythonPrinter
 
 from drudge import Drudge, Range
-from gristmill import BasePrinter, CPrinter, FortranPrinter, EinsumPrinter, OMEinsumPrinter, mangle_base
+from gristmill import (
+    BasePrinter,
+    CPrinter,
+    FortranPrinter,
+    EinsumPrinter,
+    OMEinsumPrinter,
+    mangle_base,
+)
 from gristmill.generate import (
-    TensorDecl, BeginBody, BeforeComp, CompTerm, OutOfUse, EndBody
+    TensorDecl,
+    BeginBody,
+    BeforeComp,
+    CompTerm,
+    OutOfUse,
+    EndBody,
 )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def simple_drudge(spark_ctx):
-    """Form a simple drudge with some basic information.
-    """
+    """Form a simple drudge with some basic information."""
 
     dr = Drudge(spark_ctx)
 
-    n = Symbol('n')
-    r = Range('R', 0, n)
+    n = Symbol("n")
+    r = Range("R", 0, n)
 
-    dumms = symbols('a b c d e f g')
+    dumms = symbols("a b c d e f g")
     dr.set_dumms(r, dumms)
     dr.add_resolver_for_dumms()
 
@@ -34,26 +47,28 @@ def simple_drudge(spark_ctx):
 
 @pytest.fixture
 def colourful_tensor(simple_drudge):
-    """Form a colourful tensor definition capable of large code coverage.
-    """
+    """Form a colourful tensor definition capable of large code coverage."""
 
     dr = simple_drudge
     p = dr.names
 
-    x = IndexedBase('x')
-    u = IndexedBase('u')
-    v = IndexedBase('v')
+    x = IndexedBase("x")
+    u = IndexedBase("u")
+    v = IndexedBase("v")
     dr.set_name(x, u, v)
 
-    r, s = symbols('r s')
+    r, s = symbols("r s")
     dr.set_name(r, s)
 
     a, b, c = p.R_dumms[:3]
 
-    tensor = dr.define(x[a, b], (
-            ((2 * r) / (3 * s)) * (u[b, a]) ** 2 -
-            dr.sum((c, p.R), u[a, c] * v[c, b] * c ** 2 / 2)
-    ))
+    tensor = dr.define(
+        x[a, b],
+        (
+            ((2 * r) / (3 * s)) * (u[b, a]) ** 2
+            - dr.sum((c, p.R), u[a, c] * v[c, b] * c**2 / 2)
+        ),
+    )
 
     return tensor
 
@@ -77,13 +92,13 @@ def eval_seq_deps(simple_drudge):
     p = dr.names
     a, b, c = p.a, p.b, p.c
 
-    x = IndexedBase('X')
-    y = IndexedBase('Y')
-    i1 = IndexedBase('I1')
-    i2 = IndexedBase('I2')
-    i3 = Symbol('I3')
-    r1 = IndexedBase('R1')
-    r2 = IndexedBase('R2')
+    x = IndexedBase("X")
+    y = IndexedBase("Y")
+    i1 = IndexedBase("I1")
+    i2 = IndexedBase("I2")
+    i3 = Symbol("I3")
+    r1 = IndexedBase("R1")
+    r2 = IndexedBase("R2")
 
     i1_def = dr.define_einst(i1[a, b], x[a, c] * y[c, b])
     i1_def.if_interm = True
@@ -107,22 +122,23 @@ def test_base_printer_ctx(simple_drudge, colourful_tensor):
     tensor = colourful_tensor
 
     # Process indexed names by mangling the base name.
-    with patch.object(BasePrinter, '__abstractmethods__', frozenset()):
-        printer = BasePrinter(PythonPrinter(), mangle_base(
-            lambda base, indices: base + str(len(indices))
-        ))
+    with patch.object(BasePrinter, "__abstractmethods__", frozenset()):
+        printer = BasePrinter(
+            PythonPrinter(),
+            mangle_base(lambda base, indices: base + str(len(indices))),
+        )
     ctx = printer.transl(tensor)
 
     def check_range(ctx, index):
         """Check the range information in a context for a index."""
         assert ctx.index == index
         assert ctx.range == p.R
-        assert ctx.lower == '0'
-        assert ctx.upper == 'n'
-        assert ctx.size == 'n'
+        assert ctx.lower == "0"
+        assert ctx.upper == "n"
+        assert ctx.size == "n"
 
-    assert ctx.base == 'x2'
-    for i, j in zip(ctx.indices, ['a', 'b']):
+    assert ctx.base == "x2"
+    for i, j in zip(ctx.indices, ["a", "b"]):
         check_range(i, j)
         continue
 
@@ -131,34 +147,33 @@ def test_base_printer_ctx(simple_drudge, colourful_tensor):
         if len(term.sums) == 0:
             # The transpose term.
 
-            assert term.phase == '+'
-            r = Symbol('r')
-            assert float(eval(term.numerator) / r) == 2/3
-            assert term.denominator == 's'
+            assert term.phase == "+"
+            r = Symbol("r")
+            assert float(eval(term.numerator) / r) == 2 / 3
+            assert term.denominator == "s"
 
             assert len(term.indexed_factors) == 1
             factor = term.indexed_factors[0]
-            assert factor.base == 'u2**2'
-            for i, j in zip(factor.indices, ['b', 'a']):
+            assert factor.base == "u2**2"
+            for i, j in zip(factor.indices, ["b", "a"]):
                 check_range(i, j)
                 continue
 
             assert len(term.other_factors) == 0
 
         elif len(term.sums) == 1:
+            check_range(term.sums[0], "c")
 
-            check_range(term.sums[0], 'c')
-
-            assert term.phase == '-'
+            assert term.phase == "-"
             assert float(eval(term.numerator)) == 0.5
-            assert term.denominator == '1'
+            assert term.denominator == "1"
 
             assert len(term.indexed_factors) == 2
             for factor in term.indexed_factors:
-                if factor.base == 'u2':
-                    expected = ['a', 'c']
-                elif factor.base == 'v2':
-                    expected = ['c', 'b']
+                if factor.base == "u2":
+                    expected = ["a", "c"]
+                elif factor.base == "v2":
+                    expected = ["c", "b"]
                 else:
                     assert False
                 for i, j in zip(factor.indices, expected):
@@ -167,7 +182,7 @@ def test_base_printer_ctx(simple_drudge, colourful_tensor):
                 continue
 
             assert len(term.other_factors) == 1
-            assert term.other_factors[0] == 'c**2'
+            assert term.other_factors[0] == "c**2"
 
         else:
             assert False
@@ -177,15 +192,15 @@ def test_events_generation(eval_seq_deps):
     """Test the event generation facility in the base printer."""
     eval_seq = eval_seq_deps
 
-    with patch.object(BasePrinter, '__abstractmethods__', frozenset()):
+    with patch.object(BasePrinter, "__abstractmethods__", frozenset()):
         printer = BasePrinter(PythonPrinter())
     events = printer.form_events(eval_seq)
 
-    i1 = IndexedBase('I1')
-    i2 = IndexedBase('I2')
-    i3 = Symbol('I3')
-    r1 = IndexedBase('R1')
-    r2 = IndexedBase('R2')
+    i1 = IndexedBase("I1")
+    i2 = IndexedBase("I2")
+    i3 = Symbol("I3")
+    r1 = IndexedBase("R1")
+    r2 = IndexedBase("R2")
 
     events.reverse()  # For easy popping from front.
 
@@ -282,11 +297,11 @@ def _test_fortran_code(code, dir):
 
     orig_cwd = dir.chdir()
 
-    dir.join('test.f90').write(code)
-    stat = subprocess.run(['gfortran', '-o', 'test', '-fopenmp', 'test.f90'])
+    dir.join("test.f90").write(code)
+    stat = subprocess.run(["gfortran", "-o", "test", "-fopenmp", "test.f90"])
     assert stat.returncode == 0
-    stat = subprocess.run(['./test'], stdout=subprocess.PIPE)
-    assert stat.stdout.decode().strip() == 'OK'
+    stat = subprocess.run(["./test"], stdout=subprocess.PIPE)
+    assert stat.stdout.decode().strip() == "OK"
 
     orig_cwd.chdir()
     return True
@@ -300,11 +315,11 @@ def _test_c_code(code, dir):
 
     orig_cwd = dir.chdir()
 
-    dir.join('test.c').write(code)
-    stat = subprocess.run(['gcc', '-o', 'test', 'test.c', '-lm'])
+    dir.join("test.c").write(code)
+    stat = subprocess.run(["gcc", "-o", "test", "test.c", "-lm"])
     assert stat.returncode == 0
-    stat = subprocess.run(['./test'], stdout=subprocess.PIPE)
-    assert stat.stdout.decode().strip() == 'OK'
+    stat = subprocess.run(["./test"], stdout=subprocess.PIPE)
+    assert stat.stdout.decode().strip() == "OK"
 
     orig_cwd.chdir()
     return True
@@ -374,7 +389,7 @@ def test_full_fortran_printer(eval_seq_deps, tmpdir):
 
     sep_code = printer.doprint(eval_seq, separate_decls=True)
     assert len(sep_code) == 2
-    assert evals == '\n'.join(sep_code)
+    assert evals == "\n".join(sep_code)
 
 
 _FORTRAN_FULL_TEST_CODE = """
@@ -560,7 +575,7 @@ def test_full_c_printer(eval_seq_deps, tmpdir):
 
     sep_code = printer.doprint(eval_seq, separate_decls=True)
     assert len(sep_code) == 2
-    assert evals == '\n'.join(sep_code)
+    assert evals == "\n".join(sep_code)
 
 
 _C_FULL_TEST_CODE = """
@@ -665,20 +680,17 @@ int main() {{
 
 
 def test_einsum_printer(simple_drudge):
-    """Test the basic functionality of the einsum printer.
-    """
+    """Test the basic functionality of the einsum printer."""
 
     dr = simple_drudge
     p = dr.names
     a, b, c = p.R_dumms[:3]
 
-    x = IndexedBase('x')
-    u = IndexedBase('u')
-    v = IndexedBase('v')
+    x = IndexedBase("x")
+    u = IndexedBase("u")
+    v = IndexedBase("v")
 
-    tensor = dr.define_einst(
-        x[a, b], u[b, a] ** 2 - 2 * u[a, c] * v[c, b] / 3
-    )
+    tensor = dr.define_einst(x[a, b], u[b, a] ** 2 - 2 * u[a, c] * v[c, b] / 3)
 
     printer = EinsumPrinter(base_indent=0)
     code = printer.doprint([tensor])
@@ -686,7 +698,7 @@ def test_einsum_printer(simple_drudge):
     exec_code = _EINSUM_DRIVER_CODE.format(code=code)
     env = {}
     exec(exec_code, env, {})
-    assert env['diff'] < 1.0E-5  # Arbitrary delta.
+    assert env["diff"] < 1.0e-5  # Arbitrary delta.
 
 
 _EINSUM_DRIVER_CODE = """
@@ -707,16 +719,15 @@ diff = linalg.norm(x - expected)
 
 
 def test_full_einsum_printer(eval_seq_deps):
-    """Test the full functionality of the einsum printer.
-    """
+    """Test the full functionality of the einsum printer."""
     eval_seq = eval_seq_deps
     printer = EinsumPrinter(base_indent=0)
     code = printer.doprint(eval_seq)
     exec_code = _FULL_EINSUM_DRIVER_CODE.format(eval=code)
     env = {}
     exec(exec_code, env, {})
-    assert env['diff1'] < 1.0E-5
-    assert env['diff2'] < 1.0E-5
+    assert env["diff1"] < 1.0e-5
+    assert env["diff2"] < 1.0e-5
 
 
 _FULL_EINSUM_DRIVER_CODE = """
@@ -750,17 +761,17 @@ def _test_julia_code(code, dir):
 
     Returns the result value from Julia, or None if juliacall is not available.
     """
-    
+
     # Check if juliacall is available
     try:
         from juliacall import Main as jl
     except ImportError:
         return None
-    
+
     try:
         # Execute the test code
         jl.seval(code)
-        
+
         # Return the result
         return jl
     except Exception as e:
@@ -769,32 +780,29 @@ def _test_julia_code(code, dir):
 
 
 def test_omeinsum_printer(simple_drudge, tmpdir):
-    """Test the basic functionality of the OMEinsum printer.
-    """
-    
+    """Test the basic functionality of the OMEinsum printer."""
+
     dr = simple_drudge
     p = dr.names
     a, b, c = p.R_dumms[:3]
 
-    x = IndexedBase('x')
-    u = IndexedBase('u')
-    v = IndexedBase('v')
+    x = IndexedBase("x")
+    u = IndexedBase("u")
+    v = IndexedBase("v")
 
-    tensor = dr.define_einst(
-        x[a, b], u[b, a] ** 2 - 2 * u[a, c] * v[c, b] / 3
-    )
+    tensor = dr.define_einst(x[a, b], u[b, a] ** 2 - 2 * u[a, c] * v[c, b] / 3)
 
     printer = OMEinsumPrinter()
     code = printer.doprint([tensor])
 
     julia_test_code = _OMEINSUM_DRIVER_CODE.format(code=code)
-    
+
     jl = _test_julia_code(julia_test_code, tmpdir)
     if jl is None:
         pytest.skip("Julia or OMEinsum.jl not available")
-    
+
     diff = float(jl.diff)
-    assert diff < 1.0E-5  # Arbitrary delta.
+    assert diff < 1.0e-5  # Arbitrary delta.
 
 
 _OMEINSUM_DRIVER_CODE = """
@@ -810,22 +818,21 @@ diff = maximum(abs.(x .- expected))
 
 
 def test_full_omeinsum_printer(eval_seq_deps, tmpdir):
-    """Test the full functionality of the OMEinsum printer.
-    """
+    """Test the full functionality of the OMEinsum printer."""
     eval_seq = eval_seq_deps
     printer = OMEinsumPrinter()
     code = printer.doprint(eval_seq)
-    
+
     julia_test_code = _FULL_OMEINSUM_DRIVER_CODE.format(eval=code)
-    
+
     jl = _test_julia_code(julia_test_code, tmpdir)
     if jl is None:
         pytest.skip("Julia or OMEinsum.jl not available")
-    
+
     diff1 = float(jl.diff1)
     diff2 = float(jl.diff2)
-    assert diff1 < 1.0E-5
-    assert diff2 < 1.0E-5
+    assert diff1 < 1.0e-5
+    assert diff2 < 1.0e-5
 
 
 _FULL_OMEINSUM_DRIVER_CODE = """

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -262,6 +262,11 @@ docs = [
     { name = "sphinx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "drudge", git = "https://github.com/DrudgeCAS/drudge.git?rev=master" },
@@ -276,6 +281,9 @@ requires-dist = [
     { name = "sympy", specifier = ">=1.14" },
 ]
 provides-extras = ["docs", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.16.2" }]
 
 [[package]]
 name = "idna"
@@ -812,6 +820,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Gristmill had no linter and no formatter. Drudge has both, set up in
DrudgeCAS/drudge#49. This brings gristmill in line with it.

## What is set up

- `.ruff.toml`, the same configuration drudge uses: line length 79,
  target Python 3.12, `deps` excluded, code inside docstrings formatted.
- `.github/workflows/ruff.yml`, a copy of drudge's. It runs
  `ruff format --check` and `ruff check` on pushes to master and on pull
  requests.
- `ruff>=0.16.2` in the dev dependency group, so a local `uv sync` brings
  it in. It stays out of the published `dev` extra, which is for running
  the tests.

The rule set is stated explicitly as `E4, E7, E9, F` rather than left
implicit. Ruff's defaults change between releases: ruff 0.16 widened them,
which turns a green tree into 154 errors here without a line of this
project's code changing. Drudge pins the same four for the same reason.

`E741` is ignored. Single-letter names such as `l` are the natural
spelling for tensor indices.

## What changed in the code

`ruff format` touched all 13 Python files, then nine lint findings were
fixed by hand.

The reformatting carries no behaviour. Comparing the parse tree of every
file against master confirms it: only `tests/opt_matrix_test.py` differs,
and that is where the lint fixes are. Docstrings are excluded from that
comparison, because ruff reformats code samples inside them. The only such
sample is the one in `mangle_base`, and it stays valid Python.

The three lint fixes:

- `tests/opt_matrix_test.py` unpacked five dummy symbols it never read.
- `tests/printers_test.py` imported `Float` without naming it anywhere.
  It is in fact used: two tests `eval` a printed numerator, and those
  strings name `Float`. Removing the import breaks
  `test_base_printer_ctx`, so it stays, with a comment saying why.
- `docs/conf.py` imports the package after the Sphinx settings, on
  purpose, to read the version. Marked with a `noqa`.

## Testing

`ruff check` and `ruff format --check` both clean, under 0.16.2 and
0.16.3.

The suite gives the same result as master does in the same environment:
59 passed, and the same 4 failures in `printers_test.py`, which are local
environment problems (no usable gfortran or julia here) and not related to
this change.